### PR TITLE
ModuleTesterTest.testPythonModuleExample passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ src/java/us/kbase/mobu/git.properties
 /TestAsyncPerl/
 /TestAsyncPython/
 /temp_test_callback/
+/ASimpleModule_for_unit_testingPython/

--- a/src/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/java/us/kbase/mobu/tester/ModuleTester.java
@@ -318,7 +318,7 @@ public class ModuleTester {
         String scriptPath = DirUtils.getFilePath(runDockerSh);
         String repoPath = DirUtils.getFilePath(repoDir);
         Process p = Runtime.getRuntime().exec(new String[] {"bash", 
-                scriptPath, "build", "--rm", "-t", 
+                scriptPath, "build", "--rm", "--load", "-t",
                 targetImageName, repoPath});
         List<Thread> workers = new ArrayList<Thread>();
         InputStream[] inputStreams = new InputStream[] {p.getInputStream(), p.getErrorStream()};

--- a/src/java/us/kbase/templates/module_method_spec_json.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_json.vm.properties
@@ -9,24 +9,24 @@
     "categories": ["active"],
     "widgets": {
         "input": null,
-#if ($example && ($language == "python" || $language == "java" || $language == "perl"))
-        "output": "no-display"
+#if ($example && $language == "python")
+        "output": "kbaseReportView"
 #else
         "output": null
 #end
     },
 #if ($example)
-#if($language == "python" || $language == "java" || $language == "perl")
+#if($language == "python" || $language == "perl" || $language == "java")
     "parameters": [ 
         {
-            "id": "assembly_input_ref",
+            "id": "contigset_id",
             "optional": false,
             "advanced": false,
             "allow_multiple": false,
             "default_values": [ "" ],
             "field_type": "text",
             "text_options": {
-                "valid_ws_types": [ "KBaseGenomeAnnotations.Assembly", "KBaseGenomes.ContigSet" ]
+                "valid_ws_types": [ "KBaseGenomes.ContigSet" ]
             }
         },
         {
@@ -45,25 +45,24 @@
     "behavior": {
         "service-mapping": {
             "url": "",
-            "name":"$module_name",
-            "method": "run_$module_name",
+            "name": "$module_name",
+            "method": "filter_contigs",
             "input_mapping": [
                 {
                     "narrative_system_variable": "workspace",
-                    "target_property": "workspace_name"
-                },{
-                    "narrative_system_variable": "workspace_id",
-                    "target_property": "workspace_id"
-                },{
-                    "input_parameter": "assembly_input_ref",
-                    "target_property": "assembly_input_ref",
-                    "target_type_transform": "resolved-ref"
-                },{
+                    "target_property": "workspace"
+                },
+                {
+                    "input_parameter": "contigset_id",
+                    "target_property": "contigset_id"
+                },
+                {
                     "input_parameter": "min_length",
                     "target_property": "min_length"
                 }
             ],
             "output_mapping": [
+#if ($example && $language == "python")
                 {
                     "service_method_output_path": [0,"report_name"],
                     "target_property": "report_name"
@@ -71,6 +70,27 @@
                 {
                     "service_method_output_path": [0,"report_ref"],
                     "target_property": "report_ref"
+                },
+                {
+                    "service_method_output_path": [0,"report_ref"],
+                    "target_property": "report_ref"
+                },
+                {
+                    "constant_value": "5",
+                    "target_property": "report_window_line_height"
+                },
+#end
+                {
+                    "service_method_output_path": [0],
+                    "target_property": "contig_filter_result"
+                },
+                {
+                    "input_parameter": "contigset_id",
+                    "target_property": "input_contigset_id"
+                },
+                {
+                    "input_parameter": "min_length",
+                    "target_property": "input_min_length"
                 },
                 {
                     "narrative_system_variable": "workspace",
@@ -143,26 +163,29 @@
         "service-mapping": {
             "url": "",
             "name": "$module_name",
-            "method": "run_$module_name",
+            "method": "your_method",
             "input_mapping": [
                 {
                     "narrative_system_variable": "workspace",
-                    "target_property": "workspace_name"
-                },{
-                    "narrative_system_variable": "workspace_id",
-                    "target_property": "workspace_id"
-                },{
+                    "target_argument_position": 0
+                },
+                {
                     "input_parameter": "parameter_1",
-                    "target_property": "parameter_1"
+                    "target_argument_position": 1
                 }
             ],
             "output_mapping": [
                 {
-                    "service_method_output_path": [0,"report_name"],
-                    "target_property": "report_name"
-                },{
-                    "service_method_output_path": [0,"report_ref"],
-                    "target_property": "report_ref"
+                    "service_method_output_path": [0],
+                    "target_property": "output"
+                },
+                {
+                    "input_parameter": "parameter_1",
+                    "target_property": "input"
+                },
+                {
+                    "narrative_system_variable": "workspace",
+                    "target_property": "workspaceName"
                 }
             ]
         }

--- a/src/java/us/kbase/templates/module_method_spec_yaml.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_yaml.vm.properties
@@ -1,5 +1,5 @@
 #if ($example)
-#if($language == "python" || $language == "java" || $language == "perl")
+#if($language == "python" || $language == "perl" || $language == "java")
 #
 # define display information
 #
@@ -8,7 +8,7 @@ tooltip: |
     Filters the contigs by removing contigs below a length threshold
 screenshots: []
 
-icon: null
+icon: icon.png
 
 #
 # define a set of similar methods that might be useful to the user
@@ -29,11 +29,11 @@ suggestions:
 # Configure the display and description of parameters
 #
 parameters :
-    assembly_input_ref :
+    contigset_id :
         ui-name : |
-            Assembly
+            Contig Set Name
         short-hint : |
-            The assembly to filter (will be overwritten)
+            The contig set to filter (will be overwritten)
     min_length :
         ui-name : |
             Min Length Threshold
@@ -98,7 +98,7 @@ screenshots: []
 icon: icon.png
 
 #
-# define a set of similar apps that might be useful to the user
+# define a set of similar methods that might be useful to the user
 #
 suggestions:
     apps:
@@ -106,6 +106,11 @@ suggestions:
             [app1, app2]
         next:
             [app3, app4]
+    methods:
+        related:
+            [method1, method2]
+        next:
+            [method3, method4]
 
 #
 # Configure the display and description of parameters

--- a/src/java/us/kbase/templates/module_python_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_python_impl.vm.properties
@@ -1,15 +1,11 @@
-#if ($example)
 # -*- coding: utf-8 -*-
 #BEGIN_HEADER
 # The header block is where all import statments should live
-import logging
-import os
-from pprint import pformat
-
-from Bio import SeqIO
-
-from installed_clients.AssemblyUtilClient import AssemblyUtil
-from installed_clients.KBaseReportClient import KBaseReport
+import sys
+import traceback
+import uuid
+from pprint import pprint, pformat
+from installed_clients.WorkspaceClient import Workspace
 #END_HEADER
 
 
@@ -27,49 +23,37 @@ class ${module_name}:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
 #[[    #########################################]]#
-
-    VERSION = "0.0.1"
-    GIT_URL = ""
-    GIT_COMMIT_HASH = ""
-    
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block
+    workspaceURL = None
     #END_CLASS_HEADER
     
     # config contains contents of config file in a hash or None if it couldn't
     # be found
     def __init__(self, config):
         #BEGIN_CONSTRUCTOR
-        
-        # Any configuration parameters that are important should be parsed and
-        # saved in the constructor.
-        self.callback_url = os.environ['SDK_CALLBACK_URL']
-        self.shared_folder = config['scratch']
-        logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
-                            level=logging.INFO)
+        self.workspaceURL = config['workspace-url']
         #END_CONSTRUCTOR
         pass
 
-    def run_${module_name}(self, ctx, params):
+    def filter_contigs(self, ctx, params):
         # ctx is the context object
         # return variables are: returnVal
-        #BEGIN run_${module_name}
-
-        # Print statements to stdout/stderr are captured and available as the App log
-        logging.info('Starting run_${module_name} function. Params=' + pformat(params))
+        #BEGIN filter_contigs
+        
+        # Print statements to stdout/stderr are captured and available as the method log
+        print('Starting filter contigs method.')
+        
 
         # Step 1 - Parse/examine the parameters and catch any errors
         # It is important to check that parameters exist and are defined, and that nice error
-        # messages are returned to users.  Parameter values go through basic validation when
-        # defined in a Narrative App, but advanced users or other SDK developers can call
-        # this function directly, so validation is still important.
-        logging.info('Validating parameters.')
-        if 'workspace_name' not in params:
-            raise ValueError('Parameter workspace_name is not set in input arguments')
-        workspace_name = params['workspace_name']
-        if 'assembly_input_ref' not in params:
-            raise ValueError('Parameter assembly_input_ref is not set in input arguments')
-        assembly_input_ref = params['assembly_input_ref']
+        # messages are returned to the user
+        if 'workspace' not in params:
+            raise ValueError('Parameter workspace is not set in input arguments')
+        workspace_name = params['workspace']
+        if 'contigset_id' not in params:
+            raise ValueError('Parameter contigset_id is not set in input arguments')
+        contigset_id = params['contigset_id']
         if 'min_length' not in params:
             raise ValueError('Parameter min_length is not set in input arguments')
         min_length_orig = params['min_length']
@@ -79,109 +63,150 @@ class ${module_name}:
         except ValueError:
             raise ValueError('Cannot parse integer from min_length parameter (' + str(min_length_orig) + ')')
         if min_length < 0:
-            raise ValueError('min_length parameter cannot be negative (' + str(min_length) + ')')
-
-
-        # Step 2 - Download the input data as a Fasta and
-        # We can use the AssemblyUtils module to download a FASTA file from our Assembly data object.
-        # The return object gives us the path to the file that was created.
-        logging.info('Downloading Assembly data as a Fasta file.')
-        assemblyUtil = AssemblyUtil(self.callback_url)
-        fasta_file = assemblyUtil.get_assembly_as_fasta({'ref': assembly_input_ref})
-
-
-        # Step 3 - Actually perform the filter operation, saving the good contigs to a new fasta file.
-        # We can use BioPython to parse the Fasta file and build and save the output to a file.
-        good_contigs = []
-        n_total = 0
-        n_remaining = 0
-        for record in SeqIO.parse(fasta_file['path'], 'fasta'):
-            n_total += 1
-            if len(record.seq) >= min_length:
-                good_contigs.append(record)
-                n_remaining += 1
-
-        logging.info('Filtered Assembly to ' + str(n_remaining) + ' contigs out of ' + str(n_total))
-        filtered_fasta_file = os.path.join(self.shared_folder, 'filtered.fasta')
-        SeqIO.write(good_contigs, filtered_fasta_file, 'fasta')
-
-
-        # Step 4 - Save the new Assembly back to the system
-        logging.info('Uploading filtered Assembly data.')
-        new_assembly = assemblyUtil.save_assembly_from_fasta({'file': {'path': filtered_fasta_file},
-                                                              'workspace_name': workspace_name,
-                                                              'assembly_name': fasta_file['assembly_name']
-                                                              })
-
-
-        # Step 5 - Build a Report and return
-        reportObj = {
-            'objects_created': [{'ref': new_assembly, 'description': 'Filtered contigs'}],
-            'text_message': 'Filtered Assembly to ' + str(n_remaining) + ' contigs out of ' + str(n_total)
-        }
-        report = KBaseReport(self.callback_url)
-        report_info = report.create({'report': reportObj, 'workspace_name': params['workspace_name']})
-
-
-        # STEP 6: contruct the output to send back
-        output = {'report_name': report_info['name'],
-                  'report_ref': report_info['ref'],
-                  'assembly_output': new_assembly,
-                  'n_initial_contigs': n_total,
-                  'n_contigs_removed': n_total - n_remaining,
-                  'n_contigs_remaining': n_remaining
-                  }
-        logging.info('returning:' + pformat(output))
-                
-        #END run_${module_name}
+            raise ValueError('min_length parameter shouldn\'t be negative (' + str(min_length) + ')')
         
 
-        # At some point might do deeper type checking...
-        if not isinstance(output, dict):
-            raise ValueError('Method run_${module_name} return value ' +
-                             'output is not type dict as required.')
-        # return the results
-        return [output]
+        # Step 2- Download the input data
+        # Most data will be based to your method by its workspace name.  Use the workspace to pull that data
+        # (or in many cases, subsets of that data).  The user token is used to authenticate with the KBase
+        # data stores and other services.  DO NOT PRINT OUT OR OTHERWISE SAVE USER TOKENS
+        token = ctx['token']
+        wsClient = Workspace(self.workspaceURL, token=token) 
+        try: 
+            # Note that results from the workspace are returned in a list, and the actual data is saved
+            # in the 'data' key.  So to get the ContigSet data, we get the first element of the list, and
+            # look at the 'data' field.
+            contigSet = wsClient.get_objects([{'ref': workspace_name+'/'+contigset_id}])[0]['data']
+        except:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+            orig_error = ''.join('    ' + line for line in lines)
+            raise ValueError('Error loading original ContigSet object from workspace:\n' + orig_error)
+        
+        print('Got ContigSet data.')
+        
 
-    def status(self, ctx):
-        #BEGIN_STATUS
-        returnVal = {'state': "OK",
-                     'message': "",
-                     'version': self.VERSION,
-                     'git_url': self.GIT_URL,
-                     'git_commit_hash': self.GIT_COMMIT_HASH}
-        #END_STATUS
-        return [returnVal]
-#else
-#BEGIN_HEADER
-import logging
-import os
+        # Step 3- Actually perform the filter operation, saving the good contigs to a new list
+        good_contigs = []
+        n_total = 0;
+        n_remaining = 0;
+        for contig in contigSet['contigs']:
+            n_total += 1
+            if len(contig['sequence']) >= min_length:
+                good_contigs.append(contig)
+                n_remaining += 1
 
-from installed_clients.KBaseReportClient import KBaseReport
-#END_HEADER
-#BEGIN_CLASS_HEADER
-#END_CLASS_HEADER
-#BEGIN_CONSTRUCTOR
-        self.callback_url = os.environ['SDK_CALLBACK_URL']
-        self.shared_folder = config['scratch']
-        logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
-                            level=logging.INFO)
-#END_CONSTRUCTOR
-#BEGIN run_${module_name}
-        report = KBaseReport(self.callback_url)
-        report_info = report.create({'report': {'objects_created':[],
-                                                'text_message': params['parameter_1']},
-                                                'workspace_name': params['workspace_name']})
-        output = {
-            'report_name': report_info['name'],
-            'report_ref': report_info['ref'],
+        # replace the contigs in the contigSet object in local memory
+        contigSet['contigs'] = good_contigs
+        
+        print('Filtered ContigSet to '+str(n_remaining)+' contigs out of '+str(n_total))
+        
+
+        # Step 4- Save the new ContigSet back to the Workspace
+        # When objects are saved, it is important to always set the Provenance of that object.  The basic
+        # provenance info is given to you as part of the context object.  You can add additional information
+        # to the provenance as necessary.  Here we keep a pointer to the input data object.
+        provenance = [{}]
+        if 'provenance' in ctx:
+            provenance = ctx['provenance']
+        # add additional info to provenance here, in this case the input data object reference
+        provenance[0]['input_ws_objects']=[workspace_name+'/'+contigset_id]
+
+        obj_info_list = None
+        try:
+	        obj_info_list = wsClient.save_objects({
+	                            'workspace':workspace_name,
+	                            'objects': [
+	                                {
+	                                    'type':'KBaseGenomes.ContigSet',
+	                                    'data':contigSet,
+	                                    'name':contigset_id,
+	                                    'provenance':provenance
+	                                }
+	                            ]
+	                        })
+        except:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+            orig_error = ''.join('    ' + line for line in lines)
+            raise ValueError('Error saving filtered ContigSet object to workspace:\n' + orig_error)
+        
+        info = obj_info_list[0]
+        # Workspace Object Info is a tuple defined as-
+        # absolute ref = info[6] + '/' + info[0] + '/' + info[4]
+        # 0 - obj_id objid - integer valued ID of the object
+        # 1 - obj_name name - the name of the data object
+        # 2 - type_string type - the full type of the data object as: [ModuleName].[Type]-v[major_ver].[minor_ver]
+        # 3 - timestamp save_date
+        # 4 - int version - the object version number
+        # 5 - username saved_by
+        # 6 - ws_id wsid - the unique integer valued ID of the workspace containing this object
+        # 7 - ws_name workspace - the workspace name
+        # 8 - string chsum - md5 of the sorted json content
+        # 9 - int size - size of the json content
+        # 10 - usermeta meta - dictionary of string keys/values of user set or auto generated metadata
+
+        print('saved ContigSet:'+pformat(info))
+
+
+        # Step 5- Create the Report for this method, and return the results
+        # Create a Report of the method
+        report = 'New ContigSet saved to: '+str(info[7]) + '/'+str(info[1])+'/'+str(info[4])+'\n'
+        report += 'Number of initial contigs:      '+ str(n_total) + '\n'
+        report += 'Number of contigs removed:      '+ str(n_total - n_remaining) + '\n'
+        report += 'Number of contigs in final set: '+ str(n_remaining) + '\n'
+
+        reportObj = {
+            'objects_created':[{
+                    'ref':str(info[6]) + '/'+str(info[0])+'/'+str(info[4]), 
+                    'description':'Filtered Contigs'
+                }],
+            'text_message':report
         }
-#END run_${module_name}
-#BEGIN_STATUS
-        returnVal = {'state': "OK",
-                     'message': "",
-                     'version': self.VERSION,
-                     'git_url': self.GIT_URL,
-                     'git_commit_hash': self.GIT_COMMIT_HASH}
-#END_STATUS
-#end
+
+        # generate a unique name for the Method report
+        reportName = 'filter_contigs_report_'+str(hex(uuid.getnode()))
+        report_info_list = None
+        try:
+            report_info_list = wsClient.save_objects({
+                    'id':info[6],
+                    'objects':[
+                        {
+                            'type':'KBaseReport.Report',
+                            'data':reportObj,
+                            'name':reportName,
+                            'meta':{},
+                            'hidden':1, # important!  make sure the report is hidden
+                            'provenance':provenance
+                        }
+                    ]
+                })
+        except:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+            orig_error = ''.join('    ' + line for line in lines)
+            raise ValueError('Error saving filtered ContigSet object to workspace:\n' + orig_error)
+        
+        report_info = report_info_list[0]
+
+        print('saved Report: '+pformat(report_info))
+
+        returnVal = {
+                'report_name': reportName,
+                'report_ref': str(report_info[6]) + '/' + str(report_info[0]) + '/' + str(report_info[4]),
+                'new_contigset_ref': str(info[6]) + '/'+str(info[0])+'/'+str(info[4]),
+                'n_initial_contigs':n_total,
+                'n_contigs_removed':n_total-n_remaining,
+                'n_contigs_remaining':n_remaining
+            }
+        
+        print('returning:'+pformat(returnVal))
+                
+        #END filter_contigs
+        
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, object):
+            raise ValueError('Method count_contigs return value ' +
+                             'returnVal is not type object as required.')
+        # return the results
+        return [returnVal]

--- a/src/java/us/kbase/templates/module_test_python_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_python_client.vm.properties
@@ -1,76 +1,46 @@
 # -*- coding: utf-8 -*-
-import os
-import time
 import unittest
-from configparser import ConfigParser
+import os
+import json
+import time
 
+from os import environ
+try:
+    from ConfigParser import ConfigParser  # py2
+except:
+    from configparser import ConfigParser  # py3
+
+from pprint import pprint
+
+from installed_clients.WorkspaceClient import Workspace
 from ${module_name}.${module_name}Impl import ${module_name}
 from ${module_name}.${module_name}Server import MethodContext
-from ${module_name}.authclient import KBaseAuth as _KBaseAuth
-
-#if ($example)
-from installed_clients.AssemblyUtilClient import AssemblyUtil
-#end
-from installed_clients.WorkspaceClient import Workspace
 
 
 class ${module_name}Test(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        token = os.environ.get('KB_AUTH_TOKEN', None)
-        config_file = os.environ.get('KB_DEPLOYMENT_CONFIG', None)
-        cls.cfg = {}
-        config = ConfigParser()
-        config.read(config_file)
-        for nameval in config.items('${module_name}'):
-            cls.cfg[nameval[0]] = nameval[1]
-        # Getting username from Auth profile for token
-        authServiceUrl = cls.cfg['auth-service-url']
-        auth_client = _KBaseAuth(authServiceUrl)
-        user_id = auth_client.get_user(token)
+        token = environ.get('KB_AUTH_TOKEN', None)
         # WARNING: don't call any logging methods on the context object,
         # it'll result in a NoneType error
         cls.ctx = MethodContext(None)
         cls.ctx.update({'token': token,
-                        'user_id': user_id,
                         'provenance': [
                             {'service': '${module_name}',
                              'method': 'please_never_use_it_in_production',
                              'method_params': []
                              }],
                         'authenticated': 1})
+        config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
+        cls.cfg = {}
+        config = ConfigParser()
+        config.read(config_file)
+        for nameval in config.items('${module_name}'):
+            cls.cfg[nameval[0]] = nameval[1]
         cls.wsURL = cls.cfg['workspace-url']
-        cls.wsClient = Workspace(cls.wsURL)
+        cls.wsClient = Workspace(cls.wsURL, token=token)
         cls.serviceImpl = ${module_name}(cls.cfg)
-        cls.scratch = cls.cfg['scratch']
-        cls.callback_url = os.environ['SDK_CALLBACK_URL']
-        suffix = int(time.time() * 1000)
-        cls.wsName = "test_ContigFilter_" + str(suffix)
-        ret = cls.wsClient.create_workspace({'workspace': cls.wsName})  # noqa
-#if ($example)
-        cls.prepareTestData()
-
-    @classmethod
-    def prepareTestData(cls):
-        """This function creates an assembly object for testing"""
-        fasta_content = '>seq1 something soemthing asdf\n' \
-                        'agcttttcat\n' \
-                        '>seq2\n' \
-                        'agctt\n' \
-                        '>seq3\n' \
-                        'agcttttcatgg'
-
-        filename = os.path.join(cls.scratch, 'test1.fasta')
-        with open(filename, 'w') as f:
-            f.write(fasta_content)
-        assemblyUtil = AssemblyUtil(cls.callback_url)
-        cls.assembly_ref = assemblyUtil.save_assembly_from_fasta({
-            'file': {'path': filename},
-            'workspace_name': cls.wsName,
-            'assembly_name': 'TestAssembly'
-        })
-#end
 
     @classmethod
     def tearDownClass(cls):
@@ -78,47 +48,70 @@ class ${module_name}Test(unittest.TestCase):
             cls.wsClient.delete_workspace({'workspace': cls.wsName})
             print('Test workspace was deleted')
 
-    # NOTE: According to Python unittest naming rules test method names should start from 'test'. # noqa
-#if ($example)
-    # NOTE: According to Python unittest naming rules test method names should start from 'test'. # noqa
-    def test_run_${module_name}_ok(self):
-        # call your implementation
-        ret = self.serviceImpl.run_${module_name}(self.ctx,
-                                                {'workspace_name': self.wsName,
-                                                 'assembly_input_ref': self.assembly_ref,
-                                                 'min_length': 10
-                                                 })
+    def getWsClient(self):
+        return self.__class__.wsClient
 
-        # Validate the returned data
+    def getWsName(self):
+        if hasattr(self.__class__, 'wsName'):
+            return self.__class__.wsName
+        suffix = int(time.time() * 1000)
+        wsName = "test_${module_name}_" + str(suffix)
+        ret = self.getWsClient().create_workspace({'workspace': wsName})
+        self.__class__.wsName = wsName
+        return wsName
+
+    def getImpl(self):
+        return self.__class__.serviceImpl
+
+    def getContext(self):
+        return self.__class__.ctx
+
+#if ($example)
+    def test_filter_contigs_ok(self):
+        obj_name = "contigset.1"
+        contig1 = {'id': '1', 'length': 10, 'md5': 'md5', 'sequence': 'agcttttcat'}
+        contig2 = {'id': '2', 'length': 5, 'md5': 'md5', 'sequence': 'agctt'}
+        contig3 = {'id': '3', 'length': 12, 'md5': 'md5', 'sequence': 'agcttttcatgg'}
+        obj1 = {'contigs': [contig1, contig2, contig3], 'id': 'id', 'md5': 'md5', 'name': 'name', 
+                'source': 'source', 'source_id': 'source_id', 'type': 'type'}
+        self.getWsClient().save_objects({'workspace': self.getWsName(), 'objects':
+            [{'type': 'KBaseGenomes.ContigSet', 'name': obj_name, 'data': obj1}]})
+        ret = self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
+            'contigset_id': obj_name, 'min_length': '10'})
+        obj2 = self.getWsClient().get_objects([{'ref': self.getWsName()+'/'+obj_name}])[0]['data']
+        self.assertEqual(len(obj2['contigs']), 2)
+        self.assertTrue(len(obj2['contigs'][0]['sequence']) >= 10)
+        self.assertTrue(len(obj2['contigs'][1]['sequence']) >= 10)
         self.assertEqual(ret[0]['n_initial_contigs'], 3)
         self.assertEqual(ret[0]['n_contigs_removed'], 1)
         self.assertEqual(ret[0]['n_contigs_remaining'], 2)
 
-    def test_run_${module_name}_min_len_negative(self):
-        with self.assertRaisesRegex(ValueError, 'min_length parameter cannot be negative'):
-            self.serviceImpl.run_${module_name}(self.ctx,
-                                              {'workspace_name': self.wsName,
-                                               'assembly_input_ref': '1/fake/3',
-                                               'min_length': '-10'})
+    def test_filter_contigs_err1(self):
+        with self.assertRaises(ValueError) as context:
+            self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
+                'contigset_id': 'fake', 'min_length': 10})
+        self.assertTrue('Error loading original ContigSet object' in str(context.exception))
 
-    def test_run_${module_name}_min_len_parse(self):
-        with self.assertRaisesRegex(ValueError, 'Cannot parse integer from min_length parameter'):
-            self.serviceImpl.run_${module_name}(self.ctx,
-                                              {'workspace_name': self.wsName,
-                                               'assembly_input_ref': '1/fake/3',
-                                               'min_length': 'ten'})
+    def test_filter_contigs_err2(self):
+        with self.assertRaises(ValueError) as context:
+            self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
+                'contigset_id': 'fake', 'min_length': '-10'})
+        self.assertTrue('min_length parameter shouldn\'t be negative' in str(context.exception))
 
+    def test_filter_contigs_err3(self):
+        with self.assertRaises(ValueError) as context:
+            self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
+                'contigset_id': 'fake', 'min_length': 'ten'})
+        self.assertTrue('Cannot parse integer from min_length parameter' in str(context.exception))
 #else
     def test_your_method(self):
-        # Prepare test objects in workspace if needed using
-        # self.getWsClient().save_objects({'workspace': self.getWsName(),
-        #                                  'objects': []})
+        # Prepare test objects in workspace if needed using 
+        # self.getWsClient().save_objects({'workspace': self.getWsName(), 'objects': []})
         #
         # Run your method by
         # ret = self.getImpl().your_method(self.getContext(), parameters...)
         #
         # Check returned data with
         # self.assertEqual(ret[...], ...) or other unittest methods
-        ret = self.serviceImpl.run_${module_name}(self.ctx, {'workspace_name': self.wsName,
-                                                             'parameter_1': 'Hello World!'})
-#end
+        pass
+#end        

--- a/src/java/us/kbase/templates/module_typespec.vm.properties
+++ b/src/java/us/kbase/templates/module_typespec.vm.properties
@@ -1,12 +1,51 @@
 /*
 A KBase module: ${module_name}
 #if ($example)
-This sample module contains one small method that filters contigs.
+This sample module contains one small method - filter_contigs.
 #end
 */
 
 module ${module_name} {
-#if($language == "r" && $example)
+#if ($example)
+#if($language == "python" || $language == "perl" || $language == "java")
+    /*
+        A string representing a ContigSet id.
+    */
+    typedef string contigset_id;
+
+    /*
+        A string representing a workspace name.
+    */
+    typedef string workspace_name;
+
+    typedef structure {
+        workspace_name workspace;
+        contigset_id contigset_id;
+        int min_length;
+    } FilterContigsParams;
+
+    /* 
+        The workspace ID for a ContigSet data object.
+        @id ws KBaseGenomes.ContigSet
+    */
+    typedef string ws_contigset_id;
+
+    typedef structure {
+#if($language == "python")
+        string report_name;
+        string report_ref;
+#end
+        ws_contigset_id new_contigset_ref;
+        int n_initial_contigs;
+        int n_contigs_removed;
+        int n_contigs_remaining;
+    } FilterContigsResults;
+	
+    /*
+        Filter contigs in a ContigSet by DNA length
+    */
+    funcdef filter_contigs(FilterContigsParams params) returns (FilterContigsResults) authentication required;
+#else
     /*
         A string representing a ContigSet id.
     */
@@ -26,16 +65,10 @@ module ${module_name} {
         contigset_id - the ContigSet to count.
     */
     funcdef count_contigs(workspace_name,contigset_id) returns (CountContigsResults) authentication required;
+#end
 #else
-    typedef structure {
-        string report_name;
-        string report_ref;
-    } ReportResults;
-
     /*
-        This example function accepts any number of parameters and returns results in a KBaseReport
+        Insert your typespec information here.
     */
-    funcdef run_${module_name}(mapping<string,UnspecifiedObject> params) returns (ReportResults output) authentication required;
-
 #end
 };


### PR DESCRIPTION
so does testPythonModuleError as a bonus

Steps taken
* Commented out the dockerfile editing as it was trying to access files in /kb/dev_container which doesn't exist in sdkbase2
* Found that nose failed repeatedly with the error
```
  File "/miniconda/lib/python3.6/site-packages/nose/case.py", line 346,
in __init__
    self.inst = self.cls()
TypeError: __init__() missing 1 required positional argument: 'config'
```
* While trying various things, found that reverting the python templates to an earlier version of the example code made the tests pass. Commit of reversion is 0391723. Once tests are passing we can look into restoring the example code.
  * Updated the old examples to use the new location for the workspace client.

See https://github.com/kbase/kb_sdk_plus/issues/10