### PR TITLE
Fix ModuleTesterTest.testJavaModuleExample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ src/java/us/kbase/mobu/git.properties
 /TestAsyncPython/
 /temp_test_callback/
 /ASimpleModule_for_unit_testingPython/
+/ASimpleModule_for_unit_testingJava/

--- a/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
+++ b/src/java/us/kbase/mobu/tester/test/ModuleTesterTest.java
@@ -19,11 +19,14 @@ import us.kbase.mobu.tester.ModuleTester;
 import us.kbase.scripts.test.TestConfigHelper;
 
 public class ModuleTesterTest {
+	
+	// TODO TEST move the modules into a single test directory for easy deletion
+	// TODO TEST fix tests leaving root owned files on disk
 
 	private static final String SIMPLE_MODULE_NAME = "ASimpleModule_for_unit_testing";
-	private static final boolean cleanupAfterTests = true;
+	private static final boolean CLEANUP_AFTER_TESTS = false;
 	
-	private static List<String> createdModuleNames = new ArrayList<String>();
+	private static final List<String> CREATED_MODULE_NAMES = new ArrayList<String>();
 	private static AuthToken token;
 	
     @BeforeClass
@@ -33,14 +36,15 @@ public class ModuleTesterTest {
 
 	@AfterClass
 	public static void tearDownModule() throws Exception {
-	    if (cleanupAfterTests)
-	        for (String moduleName : createdModuleNames)
-	            try {
-	                deleteDir(moduleName);
-	            } catch (Exception ex) {
-	                System.err.println("Error cleaning up module [" + 
-	                        moduleName + "]: " + ex.getMessage());
-	            }
+		if (CLEANUP_AFTER_TESTS)
+			for (String moduleName : CREATED_MODULE_NAMES)
+				try {
+					System.out.println("Deleting " + moduleName);
+					deleteDir(moduleName);
+				} catch (Exception ex) {
+					System.err.println("Error cleaning up module [" + 
+							moduleName + "]: " + ex.getMessage());
+				}
 	}
 	
 	@After
@@ -56,7 +60,7 @@ public class ModuleTesterTest {
 	
     private void init(String lang, String moduleName) throws Exception {
         deleteDir(moduleName);
-        createdModuleNames.add(moduleName);
+        CREATED_MODULE_NAMES.add(moduleName);
         ModuleInitializer initer = new ModuleInitializer(moduleName, token.getUserName(), 
                 lang, false);
         initer.initialize(true);
@@ -157,7 +161,7 @@ public class ModuleTesterTest {
         String lang = "python";
         String moduleName = SIMPLE_MODULE_NAME + "Self";
         deleteDir(moduleName);
-        createdModuleNames.add(moduleName);
+        CREATED_MODULE_NAMES.add(moduleName);
         String implInit = "" +
                 "#BEGIN_HEADER\n" +
                 "import os\n"+

--- a/src/java/us/kbase/templates/module_build_xml.vm.properties
+++ b/src/java/us/kbase/templates/module_build_xml.vm.properties
@@ -36,7 +36,7 @@
     <include name="syslog4j/syslog4j-0.9.46.jar"/>
     <include name="kbase/workspace/WorkspaceClient-0.6.0.jar"/>
 #if( $example )
-    <include name="jfasta-2.2.0-jar-with-dependencies.jar"/>
+    <include name="kbase/genomes/kbase-genomes-20140411.jar"/>
 #end
   </fileset>
 

--- a/src/java/us/kbase/templates/module_java_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_java_impl.vm.properties
@@ -1,4 +1,3 @@
-#if ($example)
 package ${java_package};
 
 import java.io.File;
@@ -11,26 +10,20 @@ import us.kbase.common.service.UObject;
 
 //BEGIN_HEADER
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
-import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
-import assemblyutil.AssemblyUtilClient;
-import assemblyutil.FastaAssemblyFile;
-import assemblyutil.GetAssemblyParams;
-import assemblyutil.SaveAssemblyParams;
-import kbasereport.CreateParams;
-import kbasereport.KBaseReportClient;
-import kbasereport.Report;
-import kbasereport.ReportInfo;
-import kbasereport.WorkspaceObject;
-import net.sf.jfasta.FASTAElement;
-import net.sf.jfasta.FASTAFileReader;
-import net.sf.jfasta.impl.FASTAElementIterator;
-import net.sf.jfasta.impl.FASTAFileReaderImpl;
-import net.sf.jfasta.impl.FASTAFileWriter;
-import ${java_package}.ReportResults;
+import us.kbase.common.service.Tuple11;
+import us.kbase.common.service.UObject;
+import us.kbase.kbasegenomes.Contig;
+import us.kbase.kbasegenomes.ContigSet;
+import us.kbase.workspace.ObjectIdentity;
+import us.kbase.workspace.ObjectSaveData;
+import us.kbase.workspace.ProvenanceAction;
+import us.kbase.workspace.SaveObjectsParams;
+import us.kbase.workspace.WorkspaceClient;
 //END_HEADER
 
 /**
@@ -43,131 +36,88 @@ public class ${java_module_name}Server extends JsonServerServlet {
     private static final long serialVersionUID = 1L;
 
     //BEGIN_CLASS_HEADER
-    private final URL callbackURL;
-    private final Path scratch;
+    private final String wsUrl;
     //END_CLASS_HEADER
 
     public ${java_module_name}Server() throws Exception {
         super("${module_name}");
         //BEGIN_CONSTRUCTOR
-        final String sdkURL = System.getenv("SDK_CALLBACK_URL");
-        try {
-            callbackURL = new URL(sdkURL);
-            System.out.println("Got SDK_CALLBACK_URL " + callbackURL);
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid SDK callback url: " + sdkURL, e);
-        }
-        scratch = Paths.get(super.config.get("scratch"));
+        wsUrl = config.get("workspace-url");
         //END_CONSTRUCTOR
     }
 
     /**
-     * <p>Original spec-file function name: run_${module_name}</p>
+     * <p>Original spec-file function name: filter_contigs</p>
      * <pre>
      * Filter contigs in a ContigSet by DNA length
      * </pre>
      * @param   params   instance of type {@link ${java_package}.FilterContigsParams FilterContigsParams}
      * @return   instance of type {@link ${java_package}.FilterContigsResults FilterContigsResults}
      */
-    @JsonServerMethod(rpc = "${method_name}.run_${module_name}", async=true)
+    @JsonServerMethod(rpc = "${method_name}.filter_contigs", async=true)
     public FilterContigsResults filterContigs(FilterContigsParams params, AuthToken authPart, RpcContext jsonRpcContext) throws Exception {
         FilterContigsResults returnVal = null;
-        //BEGIN run_${module_name}
+        //BEGIN filter_contigs
         
-        // Print statements to stdout/stderr are captured and available as the App log
-        System.out.println("Starting filter contigs. Parameters:");
-        System.out.println(params);
+        System.out.println("Starting filter contigs method.");
         
-        /* Step 1 - Parse/examine the parameters and catch any errors
-         * It is important to check that parameters exist and are defined, and that nice error
-         * messages are returned to users.  Parameter values go through basic validation when
-         * defined in a Narrative App, but advanced users or other SDK developers can call
-         * this function directly, so validation is still important.
-         */
-        final String workspaceName = params.get("workspace_name").asInstance();
-        if (workspaceName == null || workspaceName.isEmpty()) {
-            throw new IllegalArgumentException(
-                "Parameter workspace_name is not set in input arguments");
-        }
-        final String assyRef = params.get("assembly_input_ref").asInstance();
-        if (assyRef == null || assyRef.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Parameter assembly_input_ref is not set in input arguments");
-        }
-        if (!params.containsKey("min_length")) {
-            throw new IllegalArgumentException(
-            "Parameter min_length is not set in input arguments");
-        }
-        final long minLength = params.get("min_length").asInstance();
-        if (minLength < 0) {
-            throw new IllegalArgumentException("min_length parameter cannot be negative (" +
-                    minLength + ")");
+        if (params.getWorkspace() == null)
+            throw new IllegalStateException("Parameter workspace is not set in input arguments");
+        String workspaceName = params.getWorkspace();
+        if (params.getContigsetId() == null)
+            throw new IllegalStateException("Parameter contigset_id is not set in input arguments");
+        String contigsetId = params.getContigsetId();
+        if (params.getMinLength() == null)
+            throw new IllegalStateException("Parameter min_length is not set in input arguments");
+        long minLength = params.getMinLength();
+        if (minLength < 0)
+            throw new IllegalStateException("min_length parameter shouldn't be negative (" + minLength + ")");
+        
+        WorkspaceClient wc = new WorkspaceClient(new URL(this.wsUrl), authPart);
+        wc.setAuthAllowedForHttp(true);
+        ContigSet contigSet;
+        try {
+            contigSet = wc.getObjects(Arrays.asList(new ObjectIdentity().withRef(
+                    workspaceName + "/" + contigsetId))).get(0).getData().asClassInstance(ContigSet.class);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Error loading original ContigSet object from workspace", ex);
         }
         
-        /* Step 2 - Download the input data as a Fasta file
-         * We can use the AssemblyUtils module to download a FASTA file from our Assembly data
-         * object. The return object gives us the path to the file that was created.
-         */
-        System.out.println("Downloading assembly data as FASTA file.");
-        final AssemblyUtilClient assyUtil = new AssemblyUtilClient(callbackURL, authPart);
-        /* Normally this is bad practice, but the callback server (which runs on the same machine
-         * as the docker container running the method) is http only
-         * TODO Should allow the clients to not require a token, even for auth required methods,
-         * since the callback server ignores the incoming token. No need to transmit the token
-         * here.
-         */
-        assyUtil.setIsInsecureHttpConnectionAllowed(true);
-        final FastaAssemblyFile fileobj = assyUtil.getAssemblyAsFasta(new GetAssemblyParams()
-                .withRef(assyRef));
+        System.out.println("Got ContigSet data.");
 
-        /* Step 3 - Actually perform the filter operation, saving the good contigs to a new
-         * fasta file.
-         */
-        final Path out = scratch.resolve("filtered.fasta");
-        long total = 0;
-        long remaining = 0;
-        try (final FASTAFileReader fastaRead = new FASTAFileReaderImpl(
-                    new File(fileobj.getPath()));
-                final FASTAFileWriter fastaWrite = new FASTAFileWriter(out.toFile())) {
-            final FASTAElementIterator iter = fastaRead.getIterator();
-            while (iter.hasNext()) {
-                total++;
-                final FASTAElement fe = iter.next();
-                if (fe.getSequenceLength() >= minLength) {
-                    remaining++;
-                    fastaWrite.write(fe);
-                }
-            }
+        int nInitialContigs = contigSet.getContigs().size();
+        List<Contig> newContigs = new ArrayList<Contig>();
+        for(Contig ctg : contigSet.getContigs()) {
+            if (ctg.getLength() >= minLength)
+                newContigs.add(ctg);
         }
-        final String resultText = String.format("Filtered assembly to %s contigs out of %s",
-                remaining, total);
-        System.out.println(resultText);
+        int nContigsRemaining = newContigs.size();
+        contigSet.setContigs(newContigs);
         
-        // Step 4 - Save the new Assembly back to the system
+        System.out.println("Filtered ContigSet to " + nContigsRemaining + " contigs out of " + nInitialContigs);
         
-        final String newAssyRef = assyUtil.saveAssemblyFromFasta(new SaveAssemblyParams()
-                .withAssemblyName(fileobj.getAssemblyName())
-                .withWorkspaceName(workspaceName)
-                .withFile(new FastaAssemblyFile().withPath(out.toString())));
+        Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String,String>> info;
+        try {
+            info = wc.saveObjects(new SaveObjectsParams().withWorkspace(workspaceName)
+                .withObjects(Arrays.asList(new ObjectSaveData()
+                .withType("KBaseGenomes.ContigSet").withName(contigsetId)
+                .withData(new UObject(contigSet))
+                .withProvenance((List<ProvenanceAction>)jsonRpcContext.getProvenance())))).get(0);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Error saving filtered ContigSet object to workspace", ex);
+        }
+                        
+        System.out.println("saved:" + info);
         
-        // Step 5 - Build a Report and return
+        String newRef = info.getE7() + "/" + info.getE1() + "/" + info.getE5();
+        returnVal = new FilterContigsResults().withNewContigsetRef(newRef)
+                .withNInitialContigs((long)nInitialContigs)
+                .withNContigsRemoved((long)nInitialContigs - (long)nContigsRemaining)
+                .withNContigsRemaining((long)nContigsRemaining);
         
-        final KBaseReportClient kbr = new KBaseReportClient(callbackURL, authPart);
-        // see note above about bad practice
-        kbr.setIsInsecureHttpConnectionAllowed(true);
-        final ReportInfo report = kbr.create(new CreateParams().withWorkspaceName(workspaceName)
-                .withReport(new Report().withTextMessage(resultText)
-                        .withObjectsCreated(Arrays.asList(new WorkspaceObject()
-                                .withDescription("Filtered contigs")
-                                .withRef(newAssyRef)))));
-        // Step 6: contruct the output to send back
+        System.out.println("returning:" + returnVal);
         
-        returnVal = new ReportResults()
-                .withReportName(report.getName())
-                .withReportRef(report.getRef());
-
-        System.out.println("returning:\n" + returnVal);
-        //END run_${module_name}
+        //END filter_contigs
         return returnVal;
     }
 
@@ -185,49 +135,3 @@ public class ${java_module_name}Server extends JsonServerServlet {
         }
     }
 }
-#else
-//BEGIN_HEADER
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.net.MalformedURLException;
-
-import kbasereport.CreateParams;
-import kbasereport.KBaseReportClient;
-import kbasereport.Report;
-import kbasereport.ReportInfo;
-import kbasereport.WorkspaceObject;
-import ${java_package}.ReportResults;
-//END_HEADER
-//BEGIN_CLASS_HEADER
-    private final URL callbackURL;
-    private final Path scratch;
-//END_CLASS_HEADER
-//BEGIN_CONSTRUCTOR
-    final String sdkURL = System.getenv("SDK_CALLBACK_URL");
-    try {
-        callbackURL = new URL(sdkURL);
-        System.out.println("Got SDK_CALLBACK_URL " + callbackURL);
-    } catch (MalformedURLException e) {
-        throw new IllegalArgumentException("Invalid SDK callback url: " + sdkURL, e);
-    }
-    scratch = Paths.get(super.config.get("scratch"));
-//END_CONSTRUCTOR
-//BEGIN run_${module_name}
-        final KBaseReportClient kbr = new KBaseReportClient(callbackURL, authPart);
-        kbr.setIsInsecureHttpConnectionAllowed(true);
-        final String ws_name = params.get("workspace_name").asInstance();
-        final String parameter_1 = params.get("parameter_1").asInstance();
-        final ReportInfo report = kbr.create(new CreateParams()
-                                        .withWorkspaceName(ws_name)
-                                        .withReport(new Report()
-                                                .withTextMessage(parameter_1)
-                                                .withObjectsCreated(new java.util.ArrayList<WorkspaceObject>())));
-
-        returnVal = new ReportResults()
-                        .withReportName(report.getName())
-                        .withReportRef(report.getRef());
-
-//END run_${module_name}
-#end

--- a/src/java/us/kbase/templates/module_test_java_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_java_client.vm.properties
@@ -2,12 +2,10 @@ package ${java_package}.test;
 
 import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.HashMap;
 
 import junit.framework.Assert;
 
@@ -17,24 +15,18 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 #if ($example)
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import us.kbase.common.service.ServerException;
-import assemblyutil.AssemblyUtilClient;
-import assemblyutil.FastaAssemblyFile;
-import assemblyutil.SaveAssemblyParams;
-#else
-import ${java_package}.ReportResults;
+import ${java_package}.FilterContigsParams;
+import ${java_package}.FilterContigsResults;
 #end
 import ${java_package}.${java_module_name}Server;
-import us.kbase.auth.AuthConfig;
 import us.kbase.auth.AuthToken;
-import us.kbase.auth.ConfigurableAuthService;
 import us.kbase.common.service.JsonServerSyslog;
 import us.kbase.common.service.RpcContext;
 import us.kbase.common.service.UObject;
 import us.kbase.workspace.CreateWorkspaceParams;
+import us.kbase.workspace.ObjectSaveData;
 import us.kbase.workspace.ProvenanceAction;
+import us.kbase.workspace.SaveObjectsParams;
 import us.kbase.workspace.WorkspaceClient;
 import us.kbase.workspace.WorkspaceIdentity;
 
@@ -44,32 +36,19 @@ public class ${java_module_name}ServerTest {
     private static WorkspaceClient wsClient = null;
     private static String wsName = null;
     private static ${java_module_name}Server impl = null;
-    private static Path scratch;
-    private static URL callbackURL;
     
     @BeforeClass
     public static void init() throws Exception {
-        // Config loading
+        token = new AuthToken(System.getenv("KB_AUTH_TOKEN"), "fakeuser");
         String configFilePath = System.getenv("KB_DEPLOYMENT_CONFIG");
         File deploy = new File(configFilePath);
         Ini ini = new Ini(deploy);
         config = ini.get("${module_name}");
-        // Token validation
-        String authUrl = config.get("auth-service-url");
-        String authUrlInsecure = config.get("auth-service-url-allow-insecure");
-        ConfigurableAuthService authService = new ConfigurableAuthService(
-                new AuthConfig().withKBaseAuthServerURL(new URL(authUrl))
-                .withAllowInsecureURLs("true".equals(authUrlInsecure)));
-        token = authService.validateToken(System.getenv("KB_AUTH_TOKEN"));
-        // Reading URLs from config
         wsClient = new WorkspaceClient(new URL(config.get("workspace-url")), token);
-        wsClient.setIsInsecureHttpConnectionAllowed(true); // do we need this?
-        callbackURL = new URL(System.getenv("SDK_CALLBACK_URL"));
-        scratch = Paths.get(config.get("scratch"));
+        wsClient.setAuthAllowedForHttp(true);
         // These lines are necessary because we don't want to start linux syslog bridge service
         JsonServerSyslog.setStaticUseSyslog(false);
-        JsonServerSyslog.setStaticMlogFile(new File(config.get("scratch"), "test.log")
-            .getAbsolutePath());
+        JsonServerSyslog.setStaticMlogFile(new File(config.get("scratch"), "test.log").getAbsolutePath());
         impl = new ${java_module_name}Server();
     }
     
@@ -101,92 +80,68 @@ public class ${java_module_name}ServerTest {
     }
     
 #if ($example)
-    private String loadFASTA(
-            final Path filename,
-            final String objectName,
-            final String filecontents)
-            throws Exception {
-        Files.write(filename, filecontents.getBytes(StandardCharsets.UTF_8));
-        final AssemblyUtilClient assyUtil = new AssemblyUtilClient(callbackURL, token);
-        /* since the callback server is plain http need this line.
-         * CBS is on the same machine as the docker container
-         */
-        assyUtil.setIsInsecureHttpConnectionAllowed(true);
-        return assyUtil.saveAssemblyFromFasta(new SaveAssemblyParams()
-                .withAssemblyName(objectName)
-                .withWorkspaceName(getWsName())
-                .withFile(new FastaAssemblyFile().withPath(filename.toString())));
-        
-    }
-    
     @Test
-    public void test_run${java_module_name}_ok() throws Exception {
-        // First load a test FASTA file as an KBase Assembly
-        final String fastaContent = ">seq1 something something asdf\n" +
-                                    "agcttttcat\n" +
-                                    ">seq2\n" +
-                                    "agctt\n" +
-                                    ">seq3\n" +
-                                    "agcttttcatgg";
-        
-        final String ref = loadFASTA(scratch.resolve("test1.fasta"), "TestAssembly", fastaContent);
-        
-        // second, call the implementation
-        Map<String, UObject> params = new HashMap<>();
-        params.put("workspace_name", new UObject(getWsName()));
-        params.put("assembly_input_ref", new UObject(ref));
-        params.put("min_length", new UObject(10L));
-        impl.run${java_module_name}(params, token, getContext());
-
-    }
-    
-    @Test
-    public void test_run${java_module_name}_err1() throws Exception {
+    public void testFilterContigsOk() throws Exception {
+        String objName = "contigset.1";
+        Map<String, Object> contig1 = new LinkedHashMap<String, Object>();
+        contig1.put("id", "1");
+        contig1.put("length", 10);
+        contig1.put("md5", "md5");
+        contig1.put("sequence", "agcttttcat");
+        Map<String, Object> contig2 = new LinkedHashMap<String, Object>();
+        contig2.put("id", "2");
+        contig2.put("length", 5);
+        contig2.put("md5", "md5");
+        contig2.put("sequence", "agctt");
+        Map<String, Object> contig3 = new LinkedHashMap<String, Object>();
+        contig3.put("id", "3");
+        contig3.put("length", 12);
+        contig3.put("md5", "md5");
+        contig3.put("sequence", "agcttttcatgg");
+        Map<String, Object> obj = new LinkedHashMap<String, Object>();
+        obj.put("contigs", Arrays.asList(contig1, contig2, contig3));
+        obj.put("id", "id");
+        obj.put("md5", "md5");
+        obj.put("name", "name");
+        obj.put("source", "source");
+        obj.put("source_id", "source_id");
+        obj.put("type", "type");
+        wsClient.saveObjects(new SaveObjectsParams().withWorkspace(getWsName()).withObjects(Arrays.asList(
+                new ObjectSaveData().withType("KBaseGenomes.ContigSet").withName(objName).withData(new UObject(obj)))));
+        FilterContigsResults ret = impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
+                .withContigsetId(objName).withMinLength(10L), token, getContext());
+        //Assert.assertEquals(1L, (long)ret.getContigCount());
+        Assert.assertEquals(3L, (long)ret.getNInitialContigs());
+        Assert.assertEquals(1L, (long)ret.getNContigsRemoved());
+        Assert.assertEquals(2L, (long)ret.getNContigsRemaining());
         try {
-            Map<String, UObject> params = new HashMap<>();
-            params.put("workspace_name", new UObject(getWsName()));
-            params.put("assembly_input_ref", new UObject("fake/fake/1"));
-            impl.run${java_module_name}(params, token, getContext());
+            impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
+                .withContigsetId(objName), token, getContext());
             Assert.fail("Error is expected above");
-        } catch (IllegalArgumentException ex) {
-            Assert.assertEquals("Parameter min_length is not set in input arguments",
-                    ex.getMessage());
+        } catch (Exception ex) {
+            Assert.assertEquals("Parameter min_length is not set in input arguments", ex.getMessage());
         }
-    }
-    
-    @Test
-    public void test_run${java_module_name}_err2() throws Exception {
         try {
-            Map<String, UObject> params = new HashMap<>();
-            params.put("workspace_name", new UObject(getWsName()));
-            params.put("assembly_input_ref", new UObject("fake/fake/1"));
-            params.put("min_length", new UObject(-10L));
-            impl.run${java_module_name}(params, token, getContext());
+            impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
+                .withContigsetId(objName).withMinLength(-10L), token, getContext());
             Assert.fail("Error is expected above");
-        } catch (IllegalArgumentException ex) {
-            Assert.assertEquals("min_length parameter cannot be negative (-10)", ex.getMessage());
+        } catch (Exception ex) {
+            Assert.assertEquals("min_length parameter shouldn't be negative (-10)", ex.getMessage());
         }
-    }
-    
-    @Test
-    public void test_run${java_module_name}_err3() throws Exception {
         try {
-            Map<String, UObject> params = new HashMap<>();
-            params.put("workspace_name", new UObject(getWsName()));
-            params.put("assembly_input_ref", new UObject("fake"));
-            params.put("min_length", new UObject(10L));
-            impl.run${java_module_name}(params, token, getContext());
+            impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
+                .withContigsetId("fake").withMinLength(10L), token, getContext());
             Assert.fail("Error is expected above");
-        } catch (ServerException ex) {
-            Assert.assertEquals("Error on ObjectSpecification #1: Illegal number of separators " +
-                    "/ in object reference fake", ex.getMessage());
+        } catch (Exception ex) {
+            Assert.assertEquals("Error loading original ContigSet object from workspace", ex.getMessage());
         }
     }
 #else
     @Test
     public void testYourMethod() throws Exception {
-        // Prepare test data using the appropriate uploader for that method (see the KBase function
-        // catalog for help, https://narrative.kbase.us/#catalog/functions)
+        // Prepare test objects in workspace if needed using 
+        // wsClient.saveObjects(new SaveObjectsParams().withWorkspace(getWsName()).withObjects(Arrays.asList(
+        //         new ObjectSaveData().withType("SomeModule.SomeType").withName(objName).withData(new UObject(obj)))));
         //
         // Run your method by
         // YourRetType ret = impl.yourMethod(params, token);
@@ -194,10 +149,6 @@ public class ${java_module_name}ServerTest {
         // Check returned data with
         // Assert.assertEquals(..., ret.getSomeProperty());
         // ... or other JUnit methods.
-        Map<String, UObject> params = new HashMap<>();
-        params.put("workspace_name", new UObject(getWsName()));
-        params.put("parameter_1", new UObject("Hello World"));
-        final ReportResults ret = impl.run${java_module_name}(params, token, getContext());
     }
 #end
 }


### PR DESCRIPTION
testJavaModuleError was fixed for free.

Basically just rolled back the Java module templates to the last passing commit (0391723), similar to the Python templates.

Differences from that commit are
* Updated the workspace, auth and java common libs in build.xml, as auth was still looking for Globus Nexus style tokens
* Updated AuthToken construction in the test code to use the new constructor

See #10 and #11 