### PR TITLE
Make tests pass in succession

### DIFF
--- a/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
+++ b/src/java/us/kbase/mobu/renamer/test/ModuleRenamerTest.java
@@ -1,15 +1,14 @@
 package us.kbase.mobu.renamer.test;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import junit.framework.Assert;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -19,17 +18,14 @@ import us.kbase.mobu.initializer.ModuleInitializer;
 import us.kbase.mobu.renamer.ModuleRenamer;
 import us.kbase.mobu.tester.test.ModuleTesterTest;
 import us.kbase.scripts.test.TestConfigHelper;
+import us.kbase.test.sdk.TestUtils;
 
 public class ModuleRenamerTest {
-	
-	// TODO TEST CLEANUP these tests leave files on the drive that require sudo to delete
-	// TODO TEST CLEANUP prior tests in the suite also leave undeletable files which caused
-	//                   tests here to fail until the module names were changed
-	
+
     private static final String SIMPLE_MODULE_NAME = "a_SimpleModule_for_rename_unit_testing";
     private static final String TARGET_MODULE_NAME = "TargetModule_for_rename_unit_testing";
-    private static final List<File> dirsToRemove = new ArrayList<File>();
-    private static final boolean deleteTempDirs = true;
+    private static final Map<Path, Boolean> CREATED_MODULES = new HashMap<>();
+    private static final boolean DELETE_TEST_MODULES = true;
 
     private static AuthToken token = null;
 
@@ -39,30 +35,24 @@ public class ModuleRenamerTest {
     }
 
     @AfterClass
-    public static void tearDownModule() throws IOException {
-        if (deleteTempDirs) {
-            for (File module : dirsToRemove) {
-                try {
-                    System.out.println("Deleting " + module);
-                    if (module.exists() && module.isDirectory()) {
-                        FileUtils.deleteDirectory(module);
-                    }
-                } catch (Exception ex) {
-                    System.err.println("Error cleaning up module [" + 
-                            module + "]: " + ex.getMessage());
-                }
-            }
+    public static void tearDownModule() throws Exception {
+        for (final Entry<Path, Boolean> dirAndCov : CREATED_MODULES.entrySet()) {
+            TestUtils.deleteTestModule(
+                    dirAndCov.getKey(), dirAndCov.getValue(), DELETE_TEST_MODULES
+            );
         }
     }
 
-    private static File initRepo(String lang) throws Exception {
+    private static File initRepo(final String lang) throws Exception {
+        return initRepo(lang, false);
+    }
+    
+    private static File initRepo(final String lang, final boolean hasPyTestCov) throws Exception {
         final String moduleName = SIMPLE_MODULE_NAME + "_" + lang;
         final Path workDir = Paths.get(TestConfigHelper.getTempTestDir(), moduleName);
         final File ret = workDir.toFile();
-        if (ret.exists()) {
-            FileUtils.deleteDirectory(ret);
-        }
-        dirsToRemove.add(ret);
+        TestUtils.deleteTestModule(workDir, hasPyTestCov, true);
+        CREATED_MODULES.put(workDir, hasPyTestCov);
         new ModuleInitializer(
                 moduleName,
                 token.getUserName(),
@@ -85,7 +75,7 @@ public class ModuleRenamerTest {
     @Test
     public void testPython() throws Exception {
         String newModuleName = TARGET_MODULE_NAME + "_python";
-        File moduleDir = initRepo("python");
+        File moduleDir = initRepo("python", true);
         new ModuleRenamer(moduleDir).rename(newModuleName);
         int exitCode = ModuleTesterTest.runTestsInDocker(moduleDir, token);
         Assert.assertEquals(0, exitCode);
@@ -96,7 +86,7 @@ public class ModuleRenamerTest {
         String oldModuleName = "a_SimpleModule_for_unit_testing";
         String newModuleName = "a_SimpleModule_for_UnitTesting";
         String text = "" +
-        		"module-name:\n" +
+                "module-name:\n" +
                 "    " + oldModuleName + "\n" +
                 "\n" +
                 "module-description:\n" +

--- a/src/java/us/kbase/scripts/test/TestConfigHelper.java
+++ b/src/java/us/kbase/scripts/test/TestConfigHelper.java
@@ -82,4 +82,8 @@ public class TestConfigHelper {
     public static String getTempTestDir() throws Exception {
         return getTestConfigParam("test.temp.dir", true);
     }
+    
+    public static boolean getMakeRootOwnedFilesWriteable() throws Exception {
+        return getTestConfigParam("test.make-root-owned-files-writeable", "true").equals("true");
+    }
 }

--- a/src/java/us/kbase/test/sdk/TestUtils.java
+++ b/src/java/us/kbase/test/sdk/TestUtils.java
@@ -1,0 +1,84 @@
+package us.kbase.test.sdk;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.io.FileUtils;
+
+import us.kbase.mobu.util.ProcessHelper;
+import us.kbase.scripts.test.TestConfigHelper;
+
+/** Yes I know utility classes are bad etc etc */
+
+public class TestUtils {
+	
+	/** Set docker output owned by root to publicly readable, writable, and executable.
+	 * 
+	 * Some tests leave files that can only be written to by root on the drive.
+	 * 
+	 * @param moduleRoot the root of the module to modify.
+	 * @param target the directory to recursively alter, relative to /kb/module/work in the
+	 * container, where test_local/workdir is mounted.
+	 * @param ignoreMissing do nothing if the target directory does not exist or is not a
+	 * directory. Otherwise an error may be thrown.
+	 * 
+	 * @throws Exception if an error occurs.
+	 */
+	public static void makeDockerOutputWritable(
+			final Path moduleRoot,
+			final Path target,
+			boolean ignoreMissing)
+			throws Exception {
+		final Path workdir = moduleRoot.resolve("test_local/workdir");
+		final Path lclTarget = workdir.resolve(target).toRealPath();
+		if (ignoreMissing && (!Files.exists(lclTarget) || !Files.isDirectory(lclTarget))) {
+			return;
+		}
+		final Path tgt = Paths.get("/kb/module/work").resolve(target);
+		final int exitCode = ProcessHelper.cmd(
+				"docker", "run",
+				"-v", workdir.toRealPath().toString() + ":/kb/module/work",
+				"--entrypoint", "chmod",
+				// use an image that'll be used for the tests anyway
+				// should be updated if dockerfile template changes
+				"kbase/sdkbase2:latest", 
+				"-R", "o+rwx", tgt.toString()
+		).exec(moduleRoot.toFile()).getExitCode();
+		if (exitCode != 0) {
+			throw new IllegalStateException(
+					"Setting permissions on root owned files failed with exit code " + exitCode
+			);
+		}
+	}
+	
+	/** Delete an SDK module. Does nothing if the module path doesn't exist or isn't a directory.
+	 * @param module the path to the module root.
+	 * @param hasPyCov true if the module is expected to have root owned coverage data
+	 * in test_local/test_coverage, which will be set to world writable depending on the
+	 * test configuration file.
+	 * @param deleteModule if false, the module won't be deleted.
+	 * @throws Exception if an error occurs
+	 */
+	public static void deleteTestModule(
+			final Path module,
+			boolean hasPyCov,
+			boolean deleteModule)
+			throws Exception {
+		if (Files.exists(module) && Files.isDirectory(module)) {
+			if (TestConfigHelper.getMakeRootOwnedFilesWriteable() && hasPyCov) {
+				TestUtils.makeDockerOutputWritable(module, Paths.get("test_coverage"), true);
+			}
+			if (deleteModule) {
+				try {
+					System.out.println("Deleting " + module);
+					FileUtils.deleteDirectory(module.toFile());
+				} catch (Exception ex) {
+					System.err.println(
+							"Error cleaning up module [" + module + "]: " + ex.getMessage());
+				}
+			}
+		}
+	}
+
+}

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -8,3 +8,11 @@ test.auth-service-url-allow-insecure=false
 
 # A temporary directory for storing test files
 test.temp.dir=temp_kbsdkplus_test
+
+# If 'true' (the default), set files generated during tests to world writable if the're root owned.
+# Currently some tests produce files in the test docker containers which cannot be deleted
+# by a regular user. Set to 'false' to preserve the standard behavior of the containers,
+# which is how containers will behave in SDK apps. Any other values are treated as 'false'.
+# If false, the user must manually sudo delete test files or subsequent runs of the tests
+# will fail.
+test.make-root-owned-files-writeable=true


### PR DESCRIPTION
Make root owned files written by docker containers world writable before trying to delete

Fixes #12 