### PR TITLE
Restore templates from kb-sdk master branch

### DIFF
--- a/src/java/us/kbase/templates/module_build_xml.vm.properties
+++ b/src/java/us/kbase/templates/module_build_xml.vm.properties
@@ -36,7 +36,7 @@
     <include name="syslog4j/syslog4j-0.9.46.jar"/>
     <include name="kbase/workspace/WorkspaceClient-0.6.0.jar"/>
 #if( $example )
-    <include name="kbase/genomes/kbase-genomes-20140411.jar"/>
+    <include name="jfasta-2.2.0-jar-with-dependencies.jar"/>
 #end
   </fileset>
 

--- a/src/java/us/kbase/templates/module_java_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_java_impl.vm.properties
@@ -1,3 +1,4 @@
+#if ($example)
 package ${java_package};
 
 import java.io.File;
@@ -10,20 +11,26 @@ import us.kbase.common.service.UObject;
 
 //BEGIN_HEADER
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.net.MalformedURLException;
 
-import us.kbase.common.service.Tuple11;
-import us.kbase.common.service.UObject;
-import us.kbase.kbasegenomes.Contig;
-import us.kbase.kbasegenomes.ContigSet;
-import us.kbase.workspace.ObjectIdentity;
-import us.kbase.workspace.ObjectSaveData;
-import us.kbase.workspace.ProvenanceAction;
-import us.kbase.workspace.SaveObjectsParams;
-import us.kbase.workspace.WorkspaceClient;
+import assemblyutil.AssemblyUtilClient;
+import assemblyutil.FastaAssemblyFile;
+import assemblyutil.GetAssemblyParams;
+import assemblyutil.SaveAssemblyParams;
+import kbasereport.CreateParams;
+import kbasereport.KBaseReportClient;
+import kbasereport.SimpleReport;
+import kbasereport.ReportInfo;
+import kbasereport.WorkspaceObject;
+import net.sf.jfasta.FASTAElement;
+import net.sf.jfasta.FASTAFileReader;
+import net.sf.jfasta.impl.FASTAElementIterator;
+import net.sf.jfasta.impl.FASTAFileReaderImpl;
+import net.sf.jfasta.impl.FASTAFileWriter;
+import ${java_package}.ReportResults;
 //END_HEADER
 
 /**
@@ -36,88 +43,131 @@ public class ${java_module_name}Server extends JsonServerServlet {
     private static final long serialVersionUID = 1L;
 
     //BEGIN_CLASS_HEADER
-    private final String wsUrl;
+    private final URL callbackURL;
+    private final Path scratch;
     //END_CLASS_HEADER
 
     public ${java_module_name}Server() throws Exception {
         super("${module_name}");
         //BEGIN_CONSTRUCTOR
-        wsUrl = config.get("workspace-url");
+        final String sdkURL = System.getenv("SDK_CALLBACK_URL");
+        try {
+            callbackURL = new URL(sdkURL);
+            System.out.println("Got SDK_CALLBACK_URL " + callbackURL);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid SDK callback url: " + sdkURL, e);
+        }
+        scratch = Paths.get(super.config.get("scratch"));
         //END_CONSTRUCTOR
     }
 
     /**
-     * <p>Original spec-file function name: filter_contigs</p>
+     * <p>Original spec-file function name: run_${module_name}</p>
      * <pre>
      * Filter contigs in a ContigSet by DNA length
      * </pre>
      * @param   params   instance of type {@link ${java_package}.FilterContigsParams FilterContigsParams}
      * @return   instance of type {@link ${java_package}.FilterContigsResults FilterContigsResults}
      */
-    @JsonServerMethod(rpc = "${method_name}.filter_contigs", async=true)
+    @JsonServerMethod(rpc = "${method_name}.run_${module_name}", async=true)
     public FilterContigsResults filterContigs(FilterContigsParams params, AuthToken authPart, RpcContext jsonRpcContext) throws Exception {
         FilterContigsResults returnVal = null;
-        //BEGIN filter_contigs
+        //BEGIN run_${module_name}
         
-        System.out.println("Starting filter contigs method.");
+        // Print statements to stdout/stderr are captured and available as the App log
+        System.out.println("Starting filter contigs. Parameters:");
+        System.out.println(params);
         
-        if (params.getWorkspace() == null)
-            throw new IllegalStateException("Parameter workspace is not set in input arguments");
-        String workspaceName = params.getWorkspace();
-        if (params.getContigsetId() == null)
-            throw new IllegalStateException("Parameter contigset_id is not set in input arguments");
-        String contigsetId = params.getContigsetId();
-        if (params.getMinLength() == null)
-            throw new IllegalStateException("Parameter min_length is not set in input arguments");
-        long minLength = params.getMinLength();
-        if (minLength < 0)
-            throw new IllegalStateException("min_length parameter shouldn't be negative (" + minLength + ")");
-        
-        WorkspaceClient wc = new WorkspaceClient(new URL(this.wsUrl), authPart);
-        wc.setAuthAllowedForHttp(true);
-        ContigSet contigSet;
-        try {
-            contigSet = wc.getObjects(Arrays.asList(new ObjectIdentity().withRef(
-                    workspaceName + "/" + contigsetId))).get(0).getData().asClassInstance(ContigSet.class);
-        } catch (Exception ex) {
-            throw new IllegalStateException("Error loading original ContigSet object from workspace", ex);
+        /* Step 1 - Parse/examine the parameters and catch any errors
+         * It is important to check that parameters exist and are defined, and that nice error
+         * messages are returned to users.  Parameter values go through basic validation when
+         * defined in a Narrative App, but advanced users or other SDK developers can call
+         * this function directly, so validation is still important.
+         */
+        final String workspaceName = params.get("workspace_name").asInstance();
+        if (workspaceName == null || workspaceName.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Parameter workspace_name is not set in input arguments");
+        }
+        final String assyRef = params.get("assembly_input_ref").asInstance();
+        if (assyRef == null || assyRef.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Parameter assembly_input_ref is not set in input arguments");
+        }
+        if (!params.containsKey("min_length")) {
+            throw new IllegalArgumentException(
+            "Parameter min_length is not set in input arguments");
+        }
+        final long minLength = params.get("min_length").asInstance();
+        if (minLength < 0) {
+            throw new IllegalArgumentException("min_length parameter cannot be negative (" +
+                    minLength + ")");
         }
         
-        System.out.println("Got ContigSet data.");
+        /* Step 2 - Download the input data as a Fasta file
+         * We can use the AssemblyUtils module to download a FASTA file from our Assembly data
+         * object. The return object gives us the path to the file that was created.
+         */
+        System.out.println("Downloading assembly data as FASTA file.");
+        final AssemblyUtilClient assyUtil = new AssemblyUtilClient(callbackURL, authPart);
+        /* Normally this is bad practice, but the callback server (which runs on the same machine
+         * as the docker container running the method) is http only
+         * TODO Should allow the clients to not require a token, even for auth required methods,
+         * since the callback server ignores the incoming token. No need to transmit the token
+         * here.
+         */
+        assyUtil.setIsInsecureHttpConnectionAllowed(true);
+        final FastaAssemblyFile fileobj = assyUtil.getAssemblyAsFasta(new GetAssemblyParams()
+                .withRef(assyRef));
 
-        int nInitialContigs = contigSet.getContigs().size();
-        List<Contig> newContigs = new ArrayList<Contig>();
-        for(Contig ctg : contigSet.getContigs()) {
-            if (ctg.getLength() >= minLength)
-                newContigs.add(ctg);
+        /* Step 3 - Actually perform the filter operation, saving the good contigs to a new
+         * fasta file.
+         */
+        final Path out = scratch.resolve("filtered.fasta");
+        long total = 0;
+        long remaining = 0;
+        try (final FASTAFileReader fastaRead = new FASTAFileReaderImpl(
+                    new File(fileobj.getPath()));
+                final FASTAFileWriter fastaWrite = new FASTAFileWriter(out.toFile())) {
+            final FASTAElementIterator iter = fastaRead.getIterator();
+            while (iter.hasNext()) {
+                total++;
+                final FASTAElement fe = iter.next();
+                if (fe.getSequenceLength() >= minLength) {
+                    remaining++;
+                    fastaWrite.write(fe);
+                }
+            }
         }
-        int nContigsRemaining = newContigs.size();
-        contigSet.setContigs(newContigs);
+        final String resultText = String.format("Filtered assembly to %s contigs out of %s",
+                remaining, total);
+        System.out.println(resultText);
         
-        System.out.println("Filtered ContigSet to " + nContigsRemaining + " contigs out of " + nInitialContigs);
+        // Step 4 - Save the new Assembly back to the system
         
-        Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String,String>> info;
-        try {
-            info = wc.saveObjects(new SaveObjectsParams().withWorkspace(workspaceName)
-                .withObjects(Arrays.asList(new ObjectSaveData()
-                .withType("KBaseGenomes.ContigSet").withName(contigsetId)
-                .withData(new UObject(contigSet))
-                .withProvenance((List<ProvenanceAction>)jsonRpcContext.getProvenance())))).get(0);
-        } catch (Exception ex) {
-            throw new IllegalStateException("Error saving filtered ContigSet object to workspace", ex);
-        }
-                        
-        System.out.println("saved:" + info);
+        final String newAssyRef = assyUtil.saveAssemblyFromFasta(new SaveAssemblyParams()
+                .withAssemblyName(fileobj.getAssemblyName())
+                .withWorkspaceName(workspaceName)
+                .withFile(new FastaAssemblyFile().withPath(out.toString())));
         
-        String newRef = info.getE7() + "/" + info.getE1() + "/" + info.getE5();
-        returnVal = new FilterContigsResults().withNewContigsetRef(newRef)
-                .withNInitialContigs((long)nInitialContigs)
-                .withNContigsRemoved((long)nInitialContigs - (long)nContigsRemaining)
-                .withNContigsRemaining((long)nContigsRemaining);
+        // Step 5 - Build a Report and return
         
-        System.out.println("returning:" + returnVal);
+        final KBaseReportClient kbr = new KBaseReportClient(callbackURL, authPart);
+        // see note above about bad practice
+        kbr.setIsInsecureHttpConnectionAllowed(true);
+        final ReportInfo report = kbr.create(new CreateParams().withWorkspaceName(workspaceName)
+                .withReport(new SimpleReport().withTextMessage(resultText)
+                        .withObjectsCreated(Arrays.asList(new WorkspaceObject()
+                                .withDescription("Filtered contigs")
+                                .withRef(newAssyRef)))));
+        // Step 6: contruct the output to send back
         
-        //END filter_contigs
+        returnVal = new ReportResults()
+                .withReportName(report.getName())
+                .withReportRef(report.getRef());
+
+        System.out.println("returning:\n" + returnVal);
+        //END run_${module_name}
         return returnVal;
     }
 
@@ -135,3 +185,49 @@ public class ${java_module_name}Server extends JsonServerServlet {
         }
     }
 }
+#else
+//BEGIN_HEADER
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.net.MalformedURLException;
+
+import kbasereport.CreateParams;
+import kbasereport.KBaseReportClient;
+import kbasereport.SimpleReport;
+import kbasereport.ReportInfo;
+import kbasereport.WorkspaceObject;
+import ${java_package}.ReportResults;
+//END_HEADER
+//BEGIN_CLASS_HEADER
+    private final URL callbackURL;
+    private final Path scratch;
+//END_CLASS_HEADER
+//BEGIN_CONSTRUCTOR
+    final String sdkURL = System.getenv("SDK_CALLBACK_URL");
+    try {
+        callbackURL = new URL(sdkURL);
+        System.out.println("Got SDK_CALLBACK_URL " + callbackURL);
+    } catch (MalformedURLException e) {
+        throw new IllegalArgumentException("Invalid SDK callback url: " + sdkURL, e);
+    }
+    scratch = Paths.get(super.config.get("scratch"));
+//END_CONSTRUCTOR
+//BEGIN run_${module_name}
+        final KBaseReportClient kbr = new KBaseReportClient(callbackURL, authPart);
+        kbr.setIsInsecureHttpConnectionAllowed(true);
+        final String ws_name = params.get("workspace_name").asInstance();
+        final String parameter_1 = params.get("parameter_1").asInstance();
+        final ReportInfo report = kbr.create(new CreateParams()
+                                        .withWorkspaceName(ws_name)
+                                        .withReport(new SimpleReport()
+                                                .withTextMessage(parameter_1)
+                                                .withObjectsCreated(new java.util.ArrayList<WorkspaceObject>())));
+
+        returnVal = new ReportResults()
+                        .withReportName(report.getName())
+                        .withReportRef(report.getRef());
+
+//END run_${module_name}
+#end

--- a/src/java/us/kbase/templates/module_method_spec_json.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_json.vm.properties
@@ -9,24 +9,24 @@
     "categories": ["active"],
     "widgets": {
         "input": null,
-#if ($example && $language == "python")
-        "output": "kbaseReportView"
+#if ($example && ($language == "python" || $language == "java" || $language == "perl"))
+        "output": "no-display"
 #else
         "output": null
 #end
     },
 #if ($example)
-#if($language == "python" || $language == "perl" || $language == "java")
+#if($language == "python" || $language == "java" || $language == "perl")
     "parameters": [ 
         {
-            "id": "contigset_id",
+            "id": "assembly_input_ref",
             "optional": false,
             "advanced": false,
             "allow_multiple": false,
             "default_values": [ "" ],
             "field_type": "text",
             "text_options": {
-                "valid_ws_types": [ "KBaseGenomes.ContigSet" ]
+                "valid_ws_types": [ "KBaseGenomeAnnotations.Assembly", "KBaseGenomes.ContigSet" ]
             }
         },
         {
@@ -45,24 +45,25 @@
     "behavior": {
         "service-mapping": {
             "url": "",
-            "name": "$module_name",
-            "method": "filter_contigs",
+            "name":"$module_name",
+            "method": "run_$module_name",
             "input_mapping": [
                 {
                     "narrative_system_variable": "workspace",
-                    "target_property": "workspace"
-                },
-                {
-                    "input_parameter": "contigset_id",
-                    "target_property": "contigset_id"
-                },
-                {
+                    "target_property": "workspace_name"
+                },{
+                    "narrative_system_variable": "workspace_id",
+                    "target_property": "workspace_id"
+                },{
+                    "input_parameter": "assembly_input_ref",
+                    "target_property": "assembly_input_ref",
+                    "target_type_transform": "resolved-ref"
+                },{
                     "input_parameter": "min_length",
                     "target_property": "min_length"
                 }
             ],
             "output_mapping": [
-#if ($example && $language == "python")
                 {
                     "service_method_output_path": [0,"report_name"],
                     "target_property": "report_name"
@@ -70,27 +71,6 @@
                 {
                     "service_method_output_path": [0,"report_ref"],
                     "target_property": "report_ref"
-                },
-                {
-                    "service_method_output_path": [0,"report_ref"],
-                    "target_property": "report_ref"
-                },
-                {
-                    "constant_value": "5",
-                    "target_property": "report_window_line_height"
-                },
-#end
-                {
-                    "service_method_output_path": [0],
-                    "target_property": "contig_filter_result"
-                },
-                {
-                    "input_parameter": "contigset_id",
-                    "target_property": "input_contigset_id"
-                },
-                {
-                    "input_parameter": "min_length",
-                    "target_property": "input_min_length"
                 },
                 {
                     "narrative_system_variable": "workspace",
@@ -163,29 +143,26 @@
         "service-mapping": {
             "url": "",
             "name": "$module_name",
-            "method": "your_method",
+            "method": "run_$module_name",
             "input_mapping": [
                 {
                     "narrative_system_variable": "workspace",
-                    "target_argument_position": 0
-                },
-                {
+                    "target_property": "workspace_name"
+                },{
+                    "narrative_system_variable": "workspace_id",
+                    "target_property": "workspace_id"
+                },{
                     "input_parameter": "parameter_1",
-                    "target_argument_position": 1
+                    "target_property": "parameter_1"
                 }
             ],
             "output_mapping": [
                 {
-                    "service_method_output_path": [0],
-                    "target_property": "output"
-                },
-                {
-                    "input_parameter": "parameter_1",
-                    "target_property": "input"
-                },
-                {
-                    "narrative_system_variable": "workspace",
-                    "target_property": "workspaceName"
+                    "service_method_output_path": [0,"report_name"],
+                    "target_property": "report_name"
+                },{
+                    "service_method_output_path": [0,"report_ref"],
+                    "target_property": "report_ref"
                 }
             ]
         }

--- a/src/java/us/kbase/templates/module_method_spec_yaml.vm.properties
+++ b/src/java/us/kbase/templates/module_method_spec_yaml.vm.properties
@@ -1,5 +1,5 @@
 #if ($example)
-#if($language == "python" || $language == "perl" || $language == "java")
+#if($language == "python" || $language == "java" || $language == "perl")
 #
 # define display information
 #
@@ -8,7 +8,7 @@ tooltip: |
     Filters the contigs by removing contigs below a length threshold
 screenshots: []
 
-icon: icon.png
+icon: null
 
 #
 # define a set of similar methods that might be useful to the user
@@ -29,11 +29,11 @@ suggestions:
 # Configure the display and description of parameters
 #
 parameters :
-    contigset_id :
+    assembly_input_ref :
         ui-name : |
-            Contig Set Name
+            Assembly
         short-hint : |
-            The contig set to filter (will be overwritten)
+            The assembly to filter (will be overwritten)
     min_length :
         ui-name : |
             Min Length Threshold
@@ -98,7 +98,7 @@ screenshots: []
 icon: icon.png
 
 #
-# define a set of similar methods that might be useful to the user
+# define a set of similar apps that might be useful to the user
 #
 suggestions:
     apps:
@@ -106,11 +106,6 @@ suggestions:
             [app1, app2]
         next:
             [app3, app4]
-    methods:
-        related:
-            [method1, method2]
-        next:
-            [method3, method4]
 
 #
 # Configure the display and description of parameters

--- a/src/java/us/kbase/templates/module_python_impl.vm.properties
+++ b/src/java/us/kbase/templates/module_python_impl.vm.properties
@@ -1,11 +1,15 @@
+#if ($example)
 # -*- coding: utf-8 -*-
 #BEGIN_HEADER
 # The header block is where all import statments should live
-import sys
-import traceback
-import uuid
-from pprint import pprint, pformat
-from installed_clients.WorkspaceClient import Workspace
+import logging
+import os
+from pprint import pformat
+
+from Bio import SeqIO
+
+from installed_clients.AssemblyUtilClient import AssemblyUtil
+from installed_clients.KBaseReportClient import KBaseReport
 #END_HEADER
 
 
@@ -23,37 +27,49 @@ class ${module_name}:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
 #[[    #########################################]]#
+
+    VERSION = "0.0.1"
+    GIT_URL = ""
+    GIT_COMMIT_HASH = ""
+    
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block
-    workspaceURL = None
     #END_CLASS_HEADER
     
     # config contains contents of config file in a hash or None if it couldn't
     # be found
     def __init__(self, config):
         #BEGIN_CONSTRUCTOR
-        self.workspaceURL = config['workspace-url']
+        
+        # Any configuration parameters that are important should be parsed and
+        # saved in the constructor.
+        self.callback_url = os.environ['SDK_CALLBACK_URL']
+        self.shared_folder = config['scratch']
+        logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
+                            level=logging.INFO)
         #END_CONSTRUCTOR
         pass
 
-    def filter_contigs(self, ctx, params):
+    def run_${module_name}(self, ctx, params):
         # ctx is the context object
         # return variables are: returnVal
-        #BEGIN filter_contigs
-        
-        # Print statements to stdout/stderr are captured and available as the method log
-        print('Starting filter contigs method.')
-        
+        #BEGIN run_${module_name}
+
+        # Print statements to stdout/stderr are captured and available as the App log
+        logging.info('Starting run_${module_name} function. Params=' + pformat(params))
 
         # Step 1 - Parse/examine the parameters and catch any errors
         # It is important to check that parameters exist and are defined, and that nice error
-        # messages are returned to the user
-        if 'workspace' not in params:
-            raise ValueError('Parameter workspace is not set in input arguments')
-        workspace_name = params['workspace']
-        if 'contigset_id' not in params:
-            raise ValueError('Parameter contigset_id is not set in input arguments')
-        contigset_id = params['contigset_id']
+        # messages are returned to users.  Parameter values go through basic validation when
+        # defined in a Narrative App, but advanced users or other SDK developers can call
+        # this function directly, so validation is still important.
+        logging.info('Validating parameters.')
+        if 'workspace_name' not in params:
+            raise ValueError('Parameter workspace_name is not set in input arguments')
+        workspace_name = params['workspace_name']
+        if 'assembly_input_ref' not in params:
+            raise ValueError('Parameter assembly_input_ref is not set in input arguments')
+        assembly_input_ref = params['assembly_input_ref']
         if 'min_length' not in params:
             raise ValueError('Parameter min_length is not set in input arguments')
         min_length_orig = params['min_length']
@@ -63,150 +79,109 @@ class ${module_name}:
         except ValueError:
             raise ValueError('Cannot parse integer from min_length parameter (' + str(min_length_orig) + ')')
         if min_length < 0:
-            raise ValueError('min_length parameter shouldn\'t be negative (' + str(min_length) + ')')
-        
+            raise ValueError('min_length parameter cannot be negative (' + str(min_length) + ')')
 
-        # Step 2- Download the input data
-        # Most data will be based to your method by its workspace name.  Use the workspace to pull that data
-        # (or in many cases, subsets of that data).  The user token is used to authenticate with the KBase
-        # data stores and other services.  DO NOT PRINT OUT OR OTHERWISE SAVE USER TOKENS
-        token = ctx['token']
-        wsClient = Workspace(self.workspaceURL, token=token) 
-        try: 
-            # Note that results from the workspace are returned in a list, and the actual data is saved
-            # in the 'data' key.  So to get the ContigSet data, we get the first element of the list, and
-            # look at the 'data' field.
-            contigSet = wsClient.get_objects([{'ref': workspace_name+'/'+contigset_id}])[0]['data']
-        except:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            orig_error = ''.join('    ' + line for line in lines)
-            raise ValueError('Error loading original ContigSet object from workspace:\n' + orig_error)
-        
-        print('Got ContigSet data.')
-        
 
-        # Step 3- Actually perform the filter operation, saving the good contigs to a new list
+        # Step 2 - Download the input data as a Fasta and
+        # We can use the AssemblyUtils module to download a FASTA file from our Assembly data object.
+        # The return object gives us the path to the file that was created.
+        logging.info('Downloading Assembly data as a Fasta file.')
+        assemblyUtil = AssemblyUtil(self.callback_url)
+        fasta_file = assemblyUtil.get_assembly_as_fasta({'ref': assembly_input_ref})
+
+
+        # Step 3 - Actually perform the filter operation, saving the good contigs to a new fasta file.
+        # We can use BioPython to parse the Fasta file and build and save the output to a file.
         good_contigs = []
-        n_total = 0;
-        n_remaining = 0;
-        for contig in contigSet['contigs']:
+        n_total = 0
+        n_remaining = 0
+        for record in SeqIO.parse(fasta_file['path'], 'fasta'):
             n_total += 1
-            if len(contig['sequence']) >= min_length:
-                good_contigs.append(contig)
+            if len(record.seq) >= min_length:
+                good_contigs.append(record)
                 n_remaining += 1
 
-        # replace the contigs in the contigSet object in local memory
-        contigSet['contigs'] = good_contigs
-        
-        print('Filtered ContigSet to '+str(n_remaining)+' contigs out of '+str(n_total))
-        
-
-        # Step 4- Save the new ContigSet back to the Workspace
-        # When objects are saved, it is important to always set the Provenance of that object.  The basic
-        # provenance info is given to you as part of the context object.  You can add additional information
-        # to the provenance as necessary.  Here we keep a pointer to the input data object.
-        provenance = [{}]
-        if 'provenance' in ctx:
-            provenance = ctx['provenance']
-        # add additional info to provenance here, in this case the input data object reference
-        provenance[0]['input_ws_objects']=[workspace_name+'/'+contigset_id]
-
-        obj_info_list = None
-        try:
-	        obj_info_list = wsClient.save_objects({
-	                            'workspace':workspace_name,
-	                            'objects': [
-	                                {
-	                                    'type':'KBaseGenomes.ContigSet',
-	                                    'data':contigSet,
-	                                    'name':contigset_id,
-	                                    'provenance':provenance
-	                                }
-	                            ]
-	                        })
-        except:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            orig_error = ''.join('    ' + line for line in lines)
-            raise ValueError('Error saving filtered ContigSet object to workspace:\n' + orig_error)
-        
-        info = obj_info_list[0]
-        # Workspace Object Info is a tuple defined as-
-        # absolute ref = info[6] + '/' + info[0] + '/' + info[4]
-        # 0 - obj_id objid - integer valued ID of the object
-        # 1 - obj_name name - the name of the data object
-        # 2 - type_string type - the full type of the data object as: [ModuleName].[Type]-v[major_ver].[minor_ver]
-        # 3 - timestamp save_date
-        # 4 - int version - the object version number
-        # 5 - username saved_by
-        # 6 - ws_id wsid - the unique integer valued ID of the workspace containing this object
-        # 7 - ws_name workspace - the workspace name
-        # 8 - string chsum - md5 of the sorted json content
-        # 9 - int size - size of the json content
-        # 10 - usermeta meta - dictionary of string keys/values of user set or auto generated metadata
-
-        print('saved ContigSet:'+pformat(info))
+        logging.info('Filtered Assembly to ' + str(n_remaining) + ' contigs out of ' + str(n_total))
+        filtered_fasta_file = os.path.join(self.shared_folder, 'filtered.fasta')
+        SeqIO.write(good_contigs, filtered_fasta_file, 'fasta')
 
 
-        # Step 5- Create the Report for this method, and return the results
-        # Create a Report of the method
-        report = 'New ContigSet saved to: '+str(info[7]) + '/'+str(info[1])+'/'+str(info[4])+'\n'
-        report += 'Number of initial contigs:      '+ str(n_total) + '\n'
-        report += 'Number of contigs removed:      '+ str(n_total - n_remaining) + '\n'
-        report += 'Number of contigs in final set: '+ str(n_remaining) + '\n'
+        # Step 4 - Save the new Assembly back to the system
+        logging.info('Uploading filtered Assembly data.')
+        new_assembly = assemblyUtil.save_assembly_from_fasta({'file': {'path': filtered_fasta_file},
+                                                              'workspace_name': workspace_name,
+                                                              'assembly_name': fasta_file['assembly_name']
+                                                              })
 
+
+        # Step 5 - Build a Report and return
         reportObj = {
-            'objects_created':[{
-                    'ref':str(info[6]) + '/'+str(info[0])+'/'+str(info[4]), 
-                    'description':'Filtered Contigs'
-                }],
-            'text_message':report
+            'objects_created': [{'ref': new_assembly, 'description': 'Filtered contigs'}],
+            'text_message': 'Filtered Assembly to ' + str(n_remaining) + ' contigs out of ' + str(n_total)
         }
+        report = KBaseReport(self.callback_url)
+        report_info = report.create({'report': reportObj, 'workspace_name': params['workspace_name']})
 
-        # generate a unique name for the Method report
-        reportName = 'filter_contigs_report_'+str(hex(uuid.getnode()))
-        report_info_list = None
-        try:
-            report_info_list = wsClient.save_objects({
-                    'id':info[6],
-                    'objects':[
-                        {
-                            'type':'KBaseReport.Report',
-                            'data':reportObj,
-                            'name':reportName,
-                            'meta':{},
-                            'hidden':1, # important!  make sure the report is hidden
-                            'provenance':provenance
-                        }
-                    ]
-                })
-        except:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            orig_error = ''.join('    ' + line for line in lines)
-            raise ValueError('Error saving filtered ContigSet object to workspace:\n' + orig_error)
-        
-        report_info = report_info_list[0]
 
-        print('saved Report: '+pformat(report_info))
-
-        returnVal = {
-                'report_name': reportName,
-                'report_ref': str(report_info[6]) + '/' + str(report_info[0]) + '/' + str(report_info[4]),
-                'new_contigset_ref': str(info[6]) + '/'+str(info[0])+'/'+str(info[4]),
-                'n_initial_contigs':n_total,
-                'n_contigs_removed':n_total-n_remaining,
-                'n_contigs_remaining':n_remaining
-            }
-        
-        print('returning:'+pformat(returnVal))
+        # STEP 6: contruct the output to send back
+        output = {'report_name': report_info['name'],
+                  'report_ref': report_info['ref'],
+                  'assembly_output': new_assembly,
+                  'n_initial_contigs': n_total,
+                  'n_contigs_removed': n_total - n_remaining,
+                  'n_contigs_remaining': n_remaining
+                  }
+        logging.info('returning:' + pformat(output))
                 
-        #END filter_contigs
+        #END run_${module_name}
         
+
         # At some point might do deeper type checking...
-        if not isinstance(returnVal, object):
-            raise ValueError('Method count_contigs return value ' +
-                             'returnVal is not type object as required.')
+        if not isinstance(output, dict):
+            raise ValueError('Method run_${module_name} return value ' +
+                             'output is not type dict as required.')
         # return the results
+        return [output]
+
+    def status(self, ctx):
+        #BEGIN_STATUS
+        returnVal = {'state': "OK",
+                     'message': "",
+                     'version': self.VERSION,
+                     'git_url': self.GIT_URL,
+                     'git_commit_hash': self.GIT_COMMIT_HASH}
+        #END_STATUS
         return [returnVal]
+#else
+#BEGIN_HEADER
+import logging
+import os
+
+from installed_clients.KBaseReportClient import KBaseReport
+#END_HEADER
+#BEGIN_CLASS_HEADER
+#END_CLASS_HEADER
+#BEGIN_CONSTRUCTOR
+        self.callback_url = os.environ['SDK_CALLBACK_URL']
+        self.shared_folder = config['scratch']
+        logging.basicConfig(format='%(created)s %(levelname)s: %(message)s',
+                            level=logging.INFO)
+#END_CONSTRUCTOR
+#BEGIN run_${module_name}
+        report = KBaseReport(self.callback_url)
+        report_info = report.create({'report': {'objects_created':[],
+                                                'text_message': params['parameter_1']},
+                                                'workspace_name': params['workspace_name']})
+        output = {
+            'report_name': report_info['name'],
+            'report_ref': report_info['ref'],
+        }
+#END run_${module_name}
+#BEGIN_STATUS
+        returnVal = {'state': "OK",
+                     'message': "",
+                     'version': self.VERSION,
+                     'git_url': self.GIT_URL,
+                     'git_commit_hash': self.GIT_COMMIT_HASH}
+#END_STATUS
+#end

--- a/src/java/us/kbase/templates/module_test_java_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_java_client.vm.properties
@@ -2,10 +2,12 @@ package ${java_package}.test;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.HashMap;
 
 import junit.framework.Assert;
 
@@ -15,18 +17,24 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 #if ($example)
-import ${java_package}.FilterContigsParams;
-import ${java_package}.FilterContigsResults;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import us.kbase.common.service.ServerException;
+import assemblyutil.AssemblyUtilClient;
+import assemblyutil.FastaAssemblyFile;
+import assemblyutil.SaveAssemblyParams;
+#else
+import ${java_package}.ReportResults;
 #end
 import ${java_package}.${java_module_name}Server;
+import us.kbase.auth.AuthConfig;
 import us.kbase.auth.AuthToken;
+import us.kbase.auth.ConfigurableAuthService;
 import us.kbase.common.service.JsonServerSyslog;
 import us.kbase.common.service.RpcContext;
 import us.kbase.common.service.UObject;
 import us.kbase.workspace.CreateWorkspaceParams;
-import us.kbase.workspace.ObjectSaveData;
 import us.kbase.workspace.ProvenanceAction;
-import us.kbase.workspace.SaveObjectsParams;
 import us.kbase.workspace.WorkspaceClient;
 import us.kbase.workspace.WorkspaceIdentity;
 
@@ -36,19 +44,32 @@ public class ${java_module_name}ServerTest {
     private static WorkspaceClient wsClient = null;
     private static String wsName = null;
     private static ${java_module_name}Server impl = null;
+    private static Path scratch;
+    private static URL callbackURL;
     
     @BeforeClass
     public static void init() throws Exception {
-        token = new AuthToken(System.getenv("KB_AUTH_TOKEN"), "fakeuser");
+        // Config loading
         String configFilePath = System.getenv("KB_DEPLOYMENT_CONFIG");
         File deploy = new File(configFilePath);
         Ini ini = new Ini(deploy);
         config = ini.get("${module_name}");
+        // Token validation
+        String authUrl = config.get("auth-service-url");
+        String authUrlInsecure = config.get("auth-service-url-allow-insecure");
+        ConfigurableAuthService authService = new ConfigurableAuthService(
+                new AuthConfig().withKBaseAuthServerURL(new URL(authUrl))
+                .withAllowInsecureURLs("true".equals(authUrlInsecure)));
+        token = authService.validateToken(System.getenv("KB_AUTH_TOKEN"));
+        // Reading URLs from config
         wsClient = new WorkspaceClient(new URL(config.get("workspace-url")), token);
-        wsClient.setAuthAllowedForHttp(true);
+        wsClient.setIsInsecureHttpConnectionAllowed(true); // do we need this?
+        callbackURL = new URL(System.getenv("SDK_CALLBACK_URL"));
+        scratch = Paths.get(config.get("scratch"));
         // These lines are necessary because we don't want to start linux syslog bridge service
         JsonServerSyslog.setStaticUseSyslog(false);
-        JsonServerSyslog.setStaticMlogFile(new File(config.get("scratch"), "test.log").getAbsolutePath());
+        JsonServerSyslog.setStaticMlogFile(new File(config.get("scratch"), "test.log")
+            .getAbsolutePath());
         impl = new ${java_module_name}Server();
     }
     
@@ -80,68 +101,95 @@ public class ${java_module_name}ServerTest {
     }
     
 #if ($example)
+    private String loadFASTA(
+            final Path filename,
+            final String objectName,
+            final String filecontents)
+            throws Exception {
+        Files.write(filename, filecontents.getBytes(StandardCharsets.UTF_8));
+        final AssemblyUtilClient assyUtil = new AssemblyUtilClient(callbackURL, token);
+        /* since the callback server is plain http need this line.
+         * CBS is on the same machine as the docker container
+         */
+        assyUtil.setIsInsecureHttpConnectionAllowed(true);
+        return assyUtil.saveAssemblyFromFasta(new SaveAssemblyParams()
+                .withAssemblyName(objectName)
+                .withWorkspaceName(getWsName())
+                .withFile(new FastaAssemblyFile().withPath(filename.toString())));
+        
+    }
+    
     @Test
-    public void testFilterContigsOk() throws Exception {
-        String objName = "contigset.1";
-        Map<String, Object> contig1 = new LinkedHashMap<String, Object>();
-        contig1.put("id", "1");
-        contig1.put("length", 10);
-        contig1.put("md5", "md5");
-        contig1.put("sequence", "agcttttcat");
-        Map<String, Object> contig2 = new LinkedHashMap<String, Object>();
-        contig2.put("id", "2");
-        contig2.put("length", 5);
-        contig2.put("md5", "md5");
-        contig2.put("sequence", "agctt");
-        Map<String, Object> contig3 = new LinkedHashMap<String, Object>();
-        contig3.put("id", "3");
-        contig3.put("length", 12);
-        contig3.put("md5", "md5");
-        contig3.put("sequence", "agcttttcatgg");
-        Map<String, Object> obj = new LinkedHashMap<String, Object>();
-        obj.put("contigs", Arrays.asList(contig1, contig2, contig3));
-        obj.put("id", "id");
-        obj.put("md5", "md5");
-        obj.put("name", "name");
-        obj.put("source", "source");
-        obj.put("source_id", "source_id");
-        obj.put("type", "type");
-        wsClient.saveObjects(new SaveObjectsParams().withWorkspace(getWsName()).withObjects(Arrays.asList(
-                new ObjectSaveData().withType("KBaseGenomes.ContigSet").withName(objName).withData(new UObject(obj)))));
-        FilterContigsResults ret = impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
-                .withContigsetId(objName).withMinLength(10L), token, getContext());
-        //Assert.assertEquals(1L, (long)ret.getContigCount());
-        Assert.assertEquals(3L, (long)ret.getNInitialContigs());
-        Assert.assertEquals(1L, (long)ret.getNContigsRemoved());
-        Assert.assertEquals(2L, (long)ret.getNContigsRemaining());
+    public void test_run${java_module_name}_ok() throws Exception {
+        // First load a test FASTA file as an KBase Assembly
+        final String fastaContent = ">seq1 something something asdf\n" +
+                                    "agcttttcat\n" +
+                                    ">seq2\n" +
+                                    "agctt\n" +
+                                    ">seq3\n" +
+                                    "agcttttcatgg";
+        
+        final String ref = loadFASTA(scratch.resolve("test1.fasta"), "TestAssembly", fastaContent);
+        
+        // second, call the implementation
+        Map<String, UObject> params = new HashMap<>();
+        params.put("workspace_name", new UObject(getWsName()));
+        params.put("assembly_input_ref", new UObject(ref));
+        params.put("min_length", new UObject(10L));
+        impl.run${java_module_name}(params, token, getContext());
+
+    }
+    
+    @Test
+    public void test_run${java_module_name}_err1() throws Exception {
         try {
-            impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
-                .withContigsetId(objName), token, getContext());
+            Map<String, UObject> params = new HashMap<>();
+            params.put("workspace_name", new UObject(getWsName()));
+            params.put("assembly_input_ref", new UObject("fake/fake/1"));
+            impl.run${java_module_name}(params, token, getContext());
             Assert.fail("Error is expected above");
-        } catch (Exception ex) {
-            Assert.assertEquals("Parameter min_length is not set in input arguments", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Parameter min_length is not set in input arguments",
+                    ex.getMessage());
         }
+    }
+    
+    @Test
+    public void test_run${java_module_name}_err2() throws Exception {
         try {
-            impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
-                .withContigsetId(objName).withMinLength(-10L), token, getContext());
+            Map<String, UObject> params = new HashMap<>();
+            params.put("workspace_name", new UObject(getWsName()));
+            params.put("assembly_input_ref", new UObject("fake/fake/1"));
+            params.put("min_length", new UObject(-10L));
+            impl.run${java_module_name}(params, token, getContext());
             Assert.fail("Error is expected above");
-        } catch (Exception ex) {
-            Assert.assertEquals("min_length parameter shouldn't be negative (-10)", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("min_length parameter cannot be negative (-10)", ex.getMessage());
         }
+    }
+    
+    @Test
+    public void test_run${java_module_name}_err3() throws Exception {
         try {
-            impl.filterContigs(new FilterContigsParams().withWorkspace(getWsName())
-                .withContigsetId("fake").withMinLength(10L), token, getContext());
+            Map<String, UObject> params = new HashMap<>();
+            params.put("workspace_name", new UObject(getWsName()));
+            params.put("assembly_input_ref", new UObject("fake"));
+            params.put("min_length", new UObject(10L));
+            impl.run${java_module_name}(params, token, getContext());
             Assert.fail("Error is expected above");
-        } catch (Exception ex) {
-            Assert.assertEquals("Error loading original ContigSet object from workspace", ex.getMessage());
+        } catch (ServerException ex) {
+            // TODO CODE get rid of all this stupid quoting when the python SDK server is fixed
+            //           and AssemblyUtil recompiled
+            final String err = "'\"Error on ObjectSpecification #1: Illegal number of "
+                + "separators \\'/\\' in object reference \\'fake\\'\"'";
+            Assert.assertEquals(ex.getMessage(), err);
         }
     }
 #else
     @Test
     public void testYourMethod() throws Exception {
-        // Prepare test objects in workspace if needed using 
-        // wsClient.saveObjects(new SaveObjectsParams().withWorkspace(getWsName()).withObjects(Arrays.asList(
-        //         new ObjectSaveData().withType("SomeModule.SomeType").withName(objName).withData(new UObject(obj)))));
+        // Prepare test data using the appropriate uploader for that method (see the KBase function
+        // catalog for help, https://narrative.kbase.us/#catalog/functions)
         //
         // Run your method by
         // YourRetType ret = impl.yourMethod(params, token);
@@ -149,6 +197,10 @@ public class ${java_module_name}ServerTest {
         // Check returned data with
         // Assert.assertEquals(..., ret.getSomeProperty());
         // ... or other JUnit methods.
+        Map<String, UObject> params = new HashMap<>();
+        params.put("workspace_name", new UObject(getWsName()));
+        params.put("parameter_1", new UObject("Hello World"));
+        final ReportResults ret = impl.run${java_module_name}(params, token, getContext());
     }
 #end
 }

--- a/src/java/us/kbase/templates/module_test_python_client.vm.properties
+++ b/src/java/us/kbase/templates/module_test_python_client.vm.properties
@@ -1,46 +1,76 @@
 # -*- coding: utf-8 -*-
-import unittest
 import os
-import json
 import time
+import unittest
+from configparser import ConfigParser
 
-from os import environ
-try:
-    from ConfigParser import ConfigParser  # py2
-except:
-    from configparser import ConfigParser  # py3
-
-from pprint import pprint
-
-from installed_clients.WorkspaceClient import Workspace
 from ${module_name}.${module_name}Impl import ${module_name}
 from ${module_name}.${module_name}Server import MethodContext
+from ${module_name}.authclient import KBaseAuth as _KBaseAuth
+
+#if ($example)
+from installed_clients.AssemblyUtilClient import AssemblyUtil
+#end
+from installed_clients.WorkspaceClient import Workspace
 
 
 class ${module_name}Test(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        token = environ.get('KB_AUTH_TOKEN', None)
+        token = os.environ.get('KB_AUTH_TOKEN', None)
+        config_file = os.environ.get('KB_DEPLOYMENT_CONFIG', None)
+        cls.cfg = {}
+        config = ConfigParser()
+        config.read(config_file)
+        for nameval in config.items('${module_name}'):
+            cls.cfg[nameval[0]] = nameval[1]
+        # Getting username from Auth profile for token
+        authServiceUrl = cls.cfg['auth-service-url']
+        auth_client = _KBaseAuth(authServiceUrl)
+        user_id = auth_client.get_user(token)
         # WARNING: don't call any logging methods on the context object,
         # it'll result in a NoneType error
         cls.ctx = MethodContext(None)
         cls.ctx.update({'token': token,
+                        'user_id': user_id,
                         'provenance': [
                             {'service': '${module_name}',
                              'method': 'please_never_use_it_in_production',
                              'method_params': []
                              }],
                         'authenticated': 1})
-        config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
-        cls.cfg = {}
-        config = ConfigParser()
-        config.read(config_file)
-        for nameval in config.items('${module_name}'):
-            cls.cfg[nameval[0]] = nameval[1]
         cls.wsURL = cls.cfg['workspace-url']
-        cls.wsClient = Workspace(cls.wsURL, token=token)
+        cls.wsClient = Workspace(cls.wsURL)
         cls.serviceImpl = ${module_name}(cls.cfg)
+        cls.scratch = cls.cfg['scratch']
+        cls.callback_url = os.environ['SDK_CALLBACK_URL']
+        suffix = int(time.time() * 1000)
+        cls.wsName = "test_ContigFilter_" + str(suffix)
+        ret = cls.wsClient.create_workspace({'workspace': cls.wsName})  # noqa
+#if ($example)
+        cls.prepareTestData()
+
+    @classmethod
+    def prepareTestData(cls):
+        """This function creates an assembly object for testing"""
+        fasta_content = '>seq1 something soemthing asdf\n' \
+                        'agcttttcat\n' \
+                        '>seq2\n' \
+                        'agctt\n' \
+                        '>seq3\n' \
+                        'agcttttcatgg'
+
+        filename = os.path.join(cls.scratch, 'test1.fasta')
+        with open(filename, 'w') as f:
+            f.write(fasta_content)
+        assemblyUtil = AssemblyUtil(cls.callback_url)
+        cls.assembly_ref = assemblyUtil.save_assembly_from_fasta({
+            'file': {'path': filename},
+            'workspace_name': cls.wsName,
+            'assembly_name': 'TestAssembly'
+        })
+#end
 
     @classmethod
     def tearDownClass(cls):
@@ -48,70 +78,47 @@ class ${module_name}Test(unittest.TestCase):
             cls.wsClient.delete_workspace({'workspace': cls.wsName})
             print('Test workspace was deleted')
 
-    def getWsClient(self):
-        return self.__class__.wsClient
-
-    def getWsName(self):
-        if hasattr(self.__class__, 'wsName'):
-            return self.__class__.wsName
-        suffix = int(time.time() * 1000)
-        wsName = "test_${module_name}_" + str(suffix)
-        ret = self.getWsClient().create_workspace({'workspace': wsName})
-        self.__class__.wsName = wsName
-        return wsName
-
-    def getImpl(self):
-        return self.__class__.serviceImpl
-
-    def getContext(self):
-        return self.__class__.ctx
-
+    # NOTE: According to Python unittest naming rules test method names should start from 'test'. # noqa
 #if ($example)
-    def test_filter_contigs_ok(self):
-        obj_name = "contigset.1"
-        contig1 = {'id': '1', 'length': 10, 'md5': 'md5', 'sequence': 'agcttttcat'}
-        contig2 = {'id': '2', 'length': 5, 'md5': 'md5', 'sequence': 'agctt'}
-        contig3 = {'id': '3', 'length': 12, 'md5': 'md5', 'sequence': 'agcttttcatgg'}
-        obj1 = {'contigs': [contig1, contig2, contig3], 'id': 'id', 'md5': 'md5', 'name': 'name', 
-                'source': 'source', 'source_id': 'source_id', 'type': 'type'}
-        self.getWsClient().save_objects({'workspace': self.getWsName(), 'objects':
-            [{'type': 'KBaseGenomes.ContigSet', 'name': obj_name, 'data': obj1}]})
-        ret = self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
-            'contigset_id': obj_name, 'min_length': '10'})
-        obj2 = self.getWsClient().get_objects([{'ref': self.getWsName()+'/'+obj_name}])[0]['data']
-        self.assertEqual(len(obj2['contigs']), 2)
-        self.assertTrue(len(obj2['contigs'][0]['sequence']) >= 10)
-        self.assertTrue(len(obj2['contigs'][1]['sequence']) >= 10)
+    # NOTE: According to Python unittest naming rules test method names should start from 'test'. # noqa
+    def test_run_${module_name}_ok(self):
+        # call your implementation
+        ret = self.serviceImpl.run_${module_name}(self.ctx,
+                                                {'workspace_name': self.wsName,
+                                                 'assembly_input_ref': self.assembly_ref,
+                                                 'min_length': 10
+                                                 })
+
+        # Validate the returned data
         self.assertEqual(ret[0]['n_initial_contigs'], 3)
         self.assertEqual(ret[0]['n_contigs_removed'], 1)
         self.assertEqual(ret[0]['n_contigs_remaining'], 2)
 
-    def test_filter_contigs_err1(self):
-        with self.assertRaises(ValueError) as context:
-            self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
-                'contigset_id': 'fake', 'min_length': 10})
-        self.assertTrue('Error loading original ContigSet object' in str(context.exception))
+    def test_run_${module_name}_min_len_negative(self):
+        with self.assertRaisesRegex(ValueError, 'min_length parameter cannot be negative'):
+            self.serviceImpl.run_${module_name}(self.ctx,
+                                              {'workspace_name': self.wsName,
+                                               'assembly_input_ref': '1/fake/3',
+                                               'min_length': '-10'})
 
-    def test_filter_contigs_err2(self):
-        with self.assertRaises(ValueError) as context:
-            self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
-                'contigset_id': 'fake', 'min_length': '-10'})
-        self.assertTrue('min_length parameter shouldn\'t be negative' in str(context.exception))
+    def test_run_${module_name}_min_len_parse(self):
+        with self.assertRaisesRegex(ValueError, 'Cannot parse integer from min_length parameter'):
+            self.serviceImpl.run_${module_name}(self.ctx,
+                                              {'workspace_name': self.wsName,
+                                               'assembly_input_ref': '1/fake/3',
+                                               'min_length': 'ten'})
 
-    def test_filter_contigs_err3(self):
-        with self.assertRaises(ValueError) as context:
-            self.getImpl().filter_contigs(self.getContext(), {'workspace': self.getWsName(), 
-                'contigset_id': 'fake', 'min_length': 'ten'})
-        self.assertTrue('Cannot parse integer from min_length parameter' in str(context.exception))
 #else
     def test_your_method(self):
-        # Prepare test objects in workspace if needed using 
-        # self.getWsClient().save_objects({'workspace': self.getWsName(), 'objects': []})
+        # Prepare test objects in workspace if needed using
+        # self.getWsClient().save_objects({'workspace': self.getWsName(),
+        #                                  'objects': []})
         #
         # Run your method by
         # ret = self.getImpl().your_method(self.getContext(), parameters...)
         #
         # Check returned data with
         # self.assertEqual(ret[...], ...) or other unittest methods
-        pass
-#end        
+        ret = self.serviceImpl.run_${module_name}(self.ctx, {'workspace_name': self.wsName,
+                                                             'parameter_1': 'Hello World!'})
+#end

--- a/src/java/us/kbase/templates/module_typespec.vm.properties
+++ b/src/java/us/kbase/templates/module_typespec.vm.properties
@@ -1,51 +1,12 @@
 /*
 A KBase module: ${module_name}
 #if ($example)
-This sample module contains one small method - filter_contigs.
+This sample module contains one small method that filters contigs.
 #end
 */
 
 module ${module_name} {
-#if ($example)
-#if($language == "python" || $language == "perl" || $language == "java")
-    /*
-        A string representing a ContigSet id.
-    */
-    typedef string contigset_id;
-
-    /*
-        A string representing a workspace name.
-    */
-    typedef string workspace_name;
-
-    typedef structure {
-        workspace_name workspace;
-        contigset_id contigset_id;
-        int min_length;
-    } FilterContigsParams;
-
-    /* 
-        The workspace ID for a ContigSet data object.
-        @id ws KBaseGenomes.ContigSet
-    */
-    typedef string ws_contigset_id;
-
-    typedef structure {
-#if($language == "python")
-        string report_name;
-        string report_ref;
-#end
-        ws_contigset_id new_contigset_ref;
-        int n_initial_contigs;
-        int n_contigs_removed;
-        int n_contigs_remaining;
-    } FilterContigsResults;
-	
-    /*
-        Filter contigs in a ContigSet by DNA length
-    */
-    funcdef filter_contigs(FilterContigsParams params) returns (FilterContigsResults) authentication required;
-#else
+#if($language == "r" && $example)
     /*
         A string representing a ContigSet id.
     */
@@ -65,10 +26,16 @@ module ${module_name} {
         contigset_id - the ContigSet to count.
     */
     funcdef count_contigs(workspace_name,contigset_id) returns (CountContigsResults) authentication required;
-#end
 #else
+    typedef structure {
+        string report_name;
+        string report_ref;
+    } ReportResults;
+
     /*
-        Insert your typespec information here.
+        This example function accepts any number of parameters and returns results in a KBaseReport
     */
+    funcdef run_${module_name}(mapping<string,UnspecifiedObject> params) returns (ReportResults output) authentication required;
+
 #end
 };


### PR DESCRIPTION
From commit 80aebc4 with a few changes to get tests to pass

Post test file deletion needs an update, as there are now more files being left with root only perms. (#12)

Fixes #10 

Diff between kb_sdk master and this PR:
```
~/github/kbase/kb_sdk$ git show --oneline -s
80aebc4 (HEAD -> master, tag: 1.2.1, origin/master) Update release notes
and version
~/github/kbase/kb_sdk$ cd ../kb_sdk_plus/
~/github/kbase/kb_sdk_plus$ git show --oneline -s
6bc17db (HEAD -> sdkdev, origin/sdkdev, origin/main, main, dev_local)
Merge pull request #38 from kbase/sdkdev
~/github/kbase/kb_sdk_plus$ diff ../kb_sdk/src/java/us/kbase/templates/
src/java/us/kbase/templates/
Only in src/java/us/kbase/templates/: log.py
diff ../kb_sdk/src/java/us/kbase/templates/module_java_impl.vm.properties
src/java/us/kbase/templates/module_java_impl.vm.properties
25c25
< import kbasereport.Report;
---
> import kbasereport.SimpleReport;
159c159
<                 .withReport(new Report().withTextMessage(resultText)
---
>                 .withReport(new
SimpleReport().withTextMessage(resultText)
198c198
< import kbasereport.Report;
---
> import kbasereport.SimpleReport;
224c224
<                                         .withReport(new Report()
---
>                                         .withReport(new SimpleReport()
diff ../kb_sdk/src/java/us/kbase/templates/module_makefile.vm.properties
src/java/us/kbase/templates/module_makefile.vm.properties
33a34
> 		--pyclname $(SERVICE_CAPS).$(SERVICE_CAPS)Client \
diff ../kb_sdk/src/java/us/kbase/templates/module_test_java_client.vm.properties
src/java/us/kbase/templates/module_test_java_client.vm.properties
181,182c181,185
<             Assert.assertEquals("Error on ObjectSpecification #1:
Illegal number of separators " +
<                     "/ in object reference fake", ex.getMessage());
---
>             // TODO CODE get rid of all this stupid quoting when the
python SDK server is fixed
>             //           and AssemblyUtil recompiled
>             final String err = "'\"Error on ObjectSpecification #1:
Illegal number of "
>                 + "separators \\'/\\' in object reference
\\'fake\\'\"'";
>             Assert.assertEquals(ex.getMessage(), err);
```