### PR TITLE
Make tests pass in Gradle

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -15,7 +15,6 @@
 	<classpathentry kind="lib" path="../jars/lib/jars/jetty/jetty-all-7.0.0.jar"/>
 	<classpathentry kind="lib" path="../jars/lib/jars/google/jsonschema2pojo-core-0.3.6.jar"/>
 	<classpathentry kind="lib" path="../jars/lib/jars/jna/jna-3.4.0.jar"/>
-	<classpathentry kind="lib" path="../jars/lib/jars/junit/junit-4.9.jar"/>
 	<classpathentry kind="lib" path="../jars/lib/jars/apache_commons/commons-lang-2.4.jar"/>
 	<classpathentry kind="lib" path="../jars/lib/jars/servlet/servlet-api-2.5.jar"/>
 	<classpathentry kind="lib" path="../jars/lib/jars/syslog4j/syslog4j-0.9.46.jar"/>
@@ -34,5 +33,7 @@
 	<classpathentry kind="lib" path="../jars/lib/jars/kbase/common/kbase-common-0.0.23.jar"/>
 	<classpathentry kind="lib" path="../jars/lib/jars/kbase/auth/kbase-auth-0.4.4.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/annotation/javax.annotation-api-1.3.2.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/junit/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/hamcrest/hamcrest-core-1.3.jar"/>
 	<classpathentry kind="output" path="eclipse-classes"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -28,6 +28,7 @@
     <include name="codemodel/codemodel-2.4.1.jar"/>
     <include name="google/guava-18.0.jar"/>
     <include name="google/jsonschema2pojo-core-0.3.6.jar"/>
+  	<include name="hamcrest/hamcrest-core-1.3.jar"/>
     <include name="ini4j/ini4j-0.5.2.jar"/>
     <include name="j2html/j2html-0.7.jar"/>
     <include name="jackson/jackson-annotations-2.2.3.jar"/>
@@ -37,7 +38,7 @@
     <include name="jetty/jetty-all-7.0.0.jar"/>
     <include name="jna/jna-3.4.0.jar"/>
     <include name="joda/joda-time-2.2.jar"/>
-    <include name="junit/junit-4.9.jar"/>
+    <include name="junit/junit-4.12.jar"/>
     <include name="logback/logback-classic-1.1.2.jar"/>
     <include name="logback/logback-core-1.1.2.jar"/>
     <include name="servlet/servlet-api-2.5.jar"/>
@@ -74,7 +75,15 @@ giturl=${git.url}
 branch=${git.branch}
 commit=${git.commit}</echo>
     <echo>Compiling with jar directory: ${jardir}</echo>
-    <javac destdir="${classes}" srcdir="${src}" includeantruntime="false" debug="true" classpathref="compile.classpath" target="1.7" source="1.7" />
+    <javac
+      destdir="${classes}"
+      srcdir="${src}"
+      includeantruntime="false"
+      debug="true"
+      classpathref="compile.classpath"
+      target="11"
+      source="11"
+    />
     <!-- Copy resource files-->
     <copy todir="${classes}">
       <fileset dir="${src}">

--- a/src/java/name/fraser/neil/plaintext/diff_match_patch.java
+++ b/src/java/name/fraser/neil/plaintext/diff_match_patch.java
@@ -1804,6 +1804,7 @@ public class diff_match_patch {
    * @return LinkedList of Patch objects.
    * @deprecated Prefer patch_make(String text1, LinkedList<Diff> diffs).
    */
+  @Deprecated
   public LinkedList<Patch> patch_make(String text1, String text2,
       LinkedList<Diff> diffs) {
     return patch_make(text1, diffs);

--- a/src/java/us/kbase/test/sdk/TestUtils.java
+++ b/src/java/us/kbase/test/sdk/TestUtils.java
@@ -32,7 +32,7 @@ public class TestUtils {
 			boolean ignoreMissing)
 			throws Exception {
 		final Path workdir = moduleRoot.resolve("test_local/workdir");
-		final Path lclTarget = workdir.resolve(target).toRealPath();
+		final Path lclTarget = workdir.resolve(target).toAbsolutePath();
 		if (ignoreMissing && (!Files.exists(lclTarget) || !Files.isDirectory(lclTarget))) {
 			return;
 		}

--- a/src/java/us/kbase/test/sdk/scripts/TypeGeneratorTest.java
+++ b/src/java/us/kbase/test/sdk/scripts/TypeGeneratorTest.java
@@ -1031,7 +1031,8 @@ public class TypeGeneratorTest extends Assert {
 
 	private static String prepareClassPath(File libDir, List<URL> cpUrls)
 			throws Exception {
-		checkLib(new DiskFileSaver(libDir), "junit-4.9");
+		checkLib(new DiskFileSaver(libDir), "junit-4.12");
+		checkLib(new DiskFileSaver(libDir), "hamcrest-core-1.3");
 		StringBuilder classPathSB = new StringBuilder();
 		for (File jarFile : libDir.listFiles()) {
 			if (!jarFile.getName().endsWith(".jar"))


### PR DESCRIPTION
(and Ant)

* Fix HTMLGenTest not being able to find resources when Gradle separates them from the class files
* Fix Gradle bumping junit to 4.12 by just using 4.12 everywhere
    * and therefore Hamcrest
* fix a bug where if workdir isn't present in a test module at the beginning of a test the test will fail. Not sure what changed to surface this bug