### PR TITLE
Add script target to gradle & remove repo build in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,23 +46,12 @@ jobs:
         KBASE_CI_TOKEN: ${{ secrets.KBASE_CI_TOKEN }}
         KBASE_CI_TOKEN2: ${{ secrets.KBASE_CI_TOKEN2 }}
       run: |
-        export HOMEDIR=`pwd`
-        
+
         # set up python dependencies
         pip install pipenv
         pipenv sync --system --dev
 
-        # move to parent dir of homedir to install binaries etc
-        cd ..
-
-        # set up jars
-        # still need jars because ant is used to build the sdk in the tests for some reason
-        # also might be needed to run tests on java sdk modules, since they use ant
-        # TODO GRADLE after the ant build file is removed, see if jars is still needed
-        git clone https://github.com/kbase/jars
-        
         # set up test config
-        cd $HOMEDIR
         cp test.cfg.example test.cfg
         sed -i "s#^test.token=.*#test.token=$KBASE_CI_TOKEN#" test.cfg
         sed -i "s#^test.token2=.*#test.token2=$KBASE_CI_TOKEN2#" test.cfg

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id 'org.ajoberstar.grgit' version '4.1.1'
 }
 
-// TODO NEXT build script - how include built jar
 // TODO NEXT update dockerfile
 // TODO NEXT remove ant & makefile
 // TODO NEXT move to standard gradle locations
@@ -38,6 +37,29 @@ compileJava {
 	finalizedBy buildGitCommitFile
 }
 
+
+task kb_sdk_plusScript {
+	dependsOn compileJava
+	doLast {
+		def dependencies = configurations.runtimeClasspath.collect { File file ->
+			file.absolutePath
+		}
+	
+		def classpath = dependencies.join(':')
+	
+		def scriptContent = """#!/bin/sh
+
+CLASSPATH=$classpath
+MOD=us.kbase.mobu.ModuleBuilder
+
+java -cp $buildDir/classes/java/main:$buildDir/resources/main:\$CLASSPATH \$MOD \$@
+"""
+		def outfile = "$buildDir/kb-sdk"
+		file(outfile).text = scriptContent
+		file(outfile).setExecutable(true)
+	}
+}
+
 task pythonTest(type: Exec) {
 	description = 'Runs Python tests using pytest'
 	environment 'PYTHONPATH', './src/java/us/kbase/templates'
@@ -49,6 +71,7 @@ task pythonTest(type: Exec) {
 }
 
 test {
+	dependsOn kb_sdk_plusScript  // tests use script to compile sdk modules
 	dependsOn pythonTest
 	
 	maxHeapSize = "3G"

--- a/src/java/us/kbase/test/sdk/initializer/DockerClientServerTester.java
+++ b/src/java/us/kbase/test/sdk/initializer/DockerClientServerTester.java
@@ -98,16 +98,11 @@ public class DockerClientServerTester {
             final File implFile = moduleDir.resolve(implFileRelative).toFile();
             FileUtils.writeStringToFile(implFile, implInitText);
         }
-        // Making <kb_sdk>/bin/kb-sdk executable
-        // TODO TEST this seems bizarre. Why are we running make in the kb_sdk repo root?
-        //           looks like this should just recompile kb_sdk
-        if (ProcessHelper.cmd("make").exec(new File(".")).getExitCode() != 0)
-            throw new IllegalStateException("Error making kb-sdk");
-        // Running make for repo with adding <kb_sdk>/bin/kb-sdk into PATH
+        // Running make for new repo with adding <kb_sdk>/bin/kb-sdk into PATH
         File shellFile = new File(moduleDir.toFile(), "run_make.sh");
         String pathToSdk = new File(".").getCanonicalPath();
         List<String> lines = new ArrayList<String>(Arrays.asList("#!/bin/bash"));
-        lines.add("export PATH=" + pathToSdk + "/bin:$PATH");
+        lines.add("export PATH=" + pathToSdk + "/build:$PATH");
         lines.add("which kb-sdk");
         lines.add("make");
         TextUtils.writeFileLines(lines, shellFile);


### PR DESCRIPTION
Repo was being rebuilt every test for a couple of modules just to ensure the kb-sdk script was available