### PR TITLE
Don't leave 18 zillion sdk containers lying around after tests

### DIFF
--- a/src/java/us/kbase/test/sdk/TestUtils.java
+++ b/src/java/us/kbase/test/sdk/TestUtils.java
@@ -39,6 +39,7 @@ public class TestUtils {
 		final Path tgt = Paths.get("/kb/module/work").resolve(target);
 		final int exitCode = ProcessHelper.cmd(
 				"docker", "run",
+				"--rm",
 				"-v", workdir.toRealPath().toString() + ":/kb/module/work",
 				"--entrypoint", "chmod",
 				// use an image that'll be used for the tests anyway


### PR DESCRIPTION
Probably some other places this fix will be needed, but this one is particularly egregious, just had to delete several dozen containers