### PR TITLE
Update to java 17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - java-version: "11"
+          - java-version: "17"
 
     steps:
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.25_9-jdk-noble as build
+FROM eclipse-temurin:17.0.15_6-jdk-noble AS build
 # Ubuntu 24.04 LTS noble ^^
 
 RUN apt update && apt install -y git
@@ -19,7 +19,7 @@ COPY src /tmp/kbsdk/src/
 RUN ./gradlew prepareRunnableDir
 
 
-FROM eclipse-temurin:11.0.25_9-jdk-noble
+FROM eclipse-temurin:17.0.15_6-jdk-noble
 
 # install docker
 # spent too much time trying to d/l in the build step and install the debs here, not worth it

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Documentation in this readme is for developing the SDK codebase itself. If you w
 
 ## Running the tests
 
-Requires [uv](https://docs.astral.sh/uv/) and Java 11.
+Requires [uv](https://docs.astral.sh/uv/) and Java 17.
 
 * Copy `test.cfg.example` to `test.cfg` and fill it in appropriately.
 * `uv sync  --dev`
-    * This only needs to be run prior to the first test run or when the uv depencencies change.
+    * This only needs to be run prior to the first test run or when the uv dependencies change.
 * `uv run ./gradlew test`
 
 ## Notes and references

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -42,7 +42,7 @@ task buildGitCommitFile {
 }
 
 compileJava {
-	options.release = 11
+	options.release = 17
 	finalizedBy buildGitCommitFile
 }
 


### PR DESCRIPTION
That was easy

```
$ sdk use java 17.0.15-tem

$ uv run ./gradlew test
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use
--status for details
*snip*
BUILD SUCCESSFUL in 8m 23s
10 actionable tasks: 8 executed, 2 up-to-date

$ ./gradlew --version

------------------------------------------------------------
Gradle 8.13
------------------------------------------------------------

Build time:    2025-02-25 09:22:14 UTC
Revision:      073314332697ba45c16c0a0ce1891fa6794179ff

Kotlin:        2.0.21
Groovy:        3.0.22
Ant:           Apache Ant(TM) version 1.10.15 compiled on August 25 2024
Launcher JVM:  17.0.15 (Eclipse Adoptium 17.0.15+6)
Daemon JVM:    /home/<stuff>/.sdkman/candidates/java/17.0.15-tem (no JDK
specified, using current Java home)
OS:            Linux 6.11.0-25-generic amd64