### PR TITLE
Switch JCommander to Picocli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ plugins {
 // TODO TEST add a test that starts the SDK in a docker container and checks some simple cmds
 // TODO DEPS make JitPack jars for catalog and NMS and use them
 
+// TODO CODE move all code under us.kbase.sdk
+
+group = 'us.kbase.sdk'
+
 repositories {
 	mavenCentral()
 	maven {  // for syslog4j
@@ -42,6 +46,8 @@ task buildGitCommitFile {
 }
 
 compileJava {
+	// tell annotation processors the project name to avoid name collisions
+	options.compilerArgs += ["-Aproject=${project.group}/${project.name}"]
 	options.release = 17
 	finalizedBy buildGitCommitFile
 }
@@ -173,6 +179,8 @@ configurations.all {
 
 dependencies {
 
+	// required for GraalVM native compilation
+	annotationProcessor 'info.picocli:picocli-codegen:4.7.7'
 	compileOnly 'javax.servlet:servlet-api:2.5'
 
 	implementation("com.github.kbase:auth2_client_java:0.5.0") {
@@ -189,7 +197,6 @@ dependencies {
 		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 		exclude group: 'net.java.dev.jna' // don't include in runtime path
 	}
-	implementation 'com.beust:jcommander:1.48'
 	implementation "com.fasterxml.jackson.core:jackson-annotations:2.2.3"
 	implementation "com.fasterxml.jackson.core:jackson-databind:2.2.3"
 	implementation 'com.google.guava:guava:18.0'
@@ -198,6 +205,7 @@ dependencies {
 		exclude group: 'junit', module: 'junit' // bro
 	}
 	implementation 'commons-io:commons-io:2.4'
+	implementation 'info.picocli:picocli:4.7.7'
 	implementation 'org.apache.commons:commons-lang3:3.1'
 	implementation 'org.apache.velocity:velocity:1.7'
 	implementation 'org.ini4j:ini4j:0.5.2'

--- a/kb_sdk_plus.md
+++ b/kb_sdk_plus.md
@@ -78,6 +78,7 @@ and runnable while we make changes to the forked codebase.
   * Not sure what the issues are here, need to investigate
 * Figure out how to support Argonne staff, where Docker Desktop is banned
   * Is the docker engine CLI not enough?
+* Try to get the module docker images to run without root in tests and in EE2
 
 ## Post general development release
 

--- a/src/main/java/us/kbase/mobu/Language.java
+++ b/src/main/java/us/kbase/mobu/Language.java
@@ -1,0 +1,13 @@
+package us.kbase.mobu;
+
+/** The languages supported by the KB_SDK */
+public enum Language {
+	
+	// TODO CODE use this instead of passing strings all over the place
+	
+	/** The python programming language */
+	python,
+	
+	/** The Java programming language */
+	java
+}

--- a/src/main/java/us/kbase/mobu/ModuleBuilder.java
+++ b/src/main/java/us/kbase/mobu/ModuleBuilder.java
@@ -2,22 +2,22 @@ package us.kbase.mobu;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.yaml.snakeyaml.Yaml;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.Parameters;
-
+import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.HelpCommand;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 import us.kbase.mobu.compiler.RunCompileCommand;
 import us.kbase.mobu.initializer.ModuleInitializer;
 import us.kbase.mobu.installer.ClientInstaller;
@@ -27,669 +27,704 @@ import us.kbase.mobu.util.ProcessHelper;
 import us.kbase.mobu.util.TextUtils;
 import us.kbase.mobu.validator.ModuleValidator;
 
-public class ModuleBuilder {
 
-	private static final String defaultParentPackage = "us.kbase";
-	private static final String MODULE_BUILDER_SH_NAME = "kb-sdk";
+@Command(
+		name = "kb-sdk",
+		description =
+				"KBase SDK+ - a developer tool for building and validating KBase modules",
+		subcommands = {
+				HelpCommand.class,
+				ModuleBuilder.InitCommand.class,
+				ModuleBuilder.TestCommand.class,
+				ModuleBuilder.InstallCommand.class,
+				ModuleBuilder.ValidateCommand.class,
+				ModuleBuilder.CompileCommand.class,
+				ModuleBuilder.RunCommand.class,
+				ModuleBuilder.VersionCommand.class,
+		}
+)
+public class ModuleBuilder implements Runnable{
 
-	private static final String INIT_COMMAND     = "init";
-	private static final String VALIDATE_COMMAND = "validate";
-	private static final String COMPILE_COMMAND  = "compile";
-	private static final String HELP_COMMAND     = "help";
-	private static final String TEST_COMMAND     = "test";
-	private static final String VERSION_COMMAND  = "version";
-	private static final String INSTALL_COMMAND  = "install";
-	private static final String RUN_COMMAND      = "run";
+	private static final String DEFAULT_PARENT_PACKAGE = "us.kbase";
 
 	public static final String GLOBAL_SDK_HOME_ENV_VAR = "KB_SDK_HOME";
-	public static final String DEFAULT_METHOD_STORE_URL = "https://appdev.kbase.us/services/narrative_method_store/rpc";
+	public static final String DEFAULT_METHOD_STORE_URL =
+			"https://appdev.kbase.us/services/narrative_method_store/rpc";
 
-	public static final String VERSION = "1.2.1";
+	public static final String VERSION = "0.1.0";
+	
+	// keep a single source of truth for the version info
+	private static final String VERSION_INFO =
+			"KBase SDK+ version " + VERSION + " (commit " + GitCommit.COMMIT + ")";
 
-
-	public static void main(String[] args) throws Exception {
-
-		// setup the basic CLI argument parser with global -h and --help commands
-		GlobalArgs gArgs = new GlobalArgs();
-		JCommander jc = new JCommander(gArgs);
-		jc.setProgramName(MODULE_BUILDER_SH_NAME);
-
-
-		// add the 'init' command
-		InitCommandArgs initArgs = new InitCommandArgs();
-		jc.addCommand(INIT_COMMAND, initArgs);
-
-		// add the 'validate' command
-		ValidateCommandArgs validateArgs = new ValidateCommandArgs();
-		jc.addCommand(VALIDATE_COMMAND, validateArgs);
-
-		// add the 'compile' command
-		CompileCommandArgs compileArgs = new CompileCommandArgs();
-		jc.addCommand(COMPILE_COMMAND, compileArgs);
-
-		// add the 'help' command
-		HelpCommandArgs help = new HelpCommandArgs();
-		jc.addCommand(HELP_COMMAND, help);
-
-		// add the 'test' command
-		TestCommandArgs testArgs = new TestCommandArgs();
-		jc.addCommand(TEST_COMMAND, testArgs);
-
-		// add the 'version' command
-		VersionCommandArgs versionArgs = new VersionCommandArgs();
-		jc.addCommand(VERSION_COMMAND, versionArgs);
-
-		// add the 'install' command
-		InstallCommandArgs installArgs = new InstallCommandArgs();
-		jc.addCommand(INSTALL_COMMAND, installArgs);
-
-		// add the 'run' command
-		RunCommandArgs runArgs = new RunCommandArgs();
-		jc.addCommand(RUN_COMMAND, runArgs);
-
-		// parse the arguments and gracefully catch any errors
-		try {
-			jc.parse(args);
-		} catch (RuntimeException e) {
-			showError("Command Line Argument Error", e.getMessage());
-			System.exit(1);
-		}
-
-		// if the help flag is set, then show some help and exit
-		if(gArgs.help) {
-			showBriefHelp(jc, System.out);
-			return;
-		}
-
-		// no command entered, just print brief info and exit
-		if(jc.getParsedCommand()==null) {
-			showBriefHelp(jc, System.out);
-			return;
-		}
-
-		// if we get here, we have a valid command, so process it and do stuff
-		int returnCode = 0;
-		if(jc.getParsedCommand().equals(HELP_COMMAND)) {
-			showCommandUsage(jc,help,System.out);
-
-		} else if(jc.getParsedCommand().equals(INIT_COMMAND)) {
-			returnCode = runInitCommand(initArgs,jc);
-		} else if(jc.getParsedCommand().equals(VALIDATE_COMMAND)) {
-			returnCode = runValidateCommand(validateArgs,jc);
-		} else if(jc.getParsedCommand().equals(COMPILE_COMMAND)) {
-			returnCode = runCompileCommand(compileArgs,jc);
-		} else if(jc.getParsedCommand().equals(TEST_COMMAND)) {
-			returnCode = runTestCommand(testArgs,jc);
-		} else if (jc.getParsedCommand().equals(VERSION_COMMAND)) {
-			returnCode = runVersionCommand(versionArgs, jc);
-		} else if (jc.getParsedCommand().equals(INSTALL_COMMAND)) {
-			returnCode = runInstallCommand(installArgs, jc);
-		} else if (jc.getParsedCommand().equals(RUN_COMMAND)) {
-			returnCode = runRunCommand(runArgs, jc);
-		}
-
-		if(returnCode!=0) {
-			System.exit(returnCode);
-		}
+	public static void main(final String[] args) throws Exception {
+		final int exitCode = new CommandLine(new ModuleBuilder()).execute(args);
+		System.exit(exitCode);
 	}
 
-	private static int runValidateCommand(ValidateCommandArgs validateArgs, JCommander jc) {
-		// initialize 
-		if(validateArgs.modules==null) {
-			validateArgs.modules = new ArrayList<String>();
-		}
-		if(validateArgs.modules.size()==0) {
-			validateArgs.modules.add(".");
-		}
-		try {
-			ModuleValidator mv = new ModuleValidator(validateArgs.modules,validateArgs.verbose,
-					validateArgs.methodStoreUrl, validateArgs.allowSyncMethods);
-			return mv.validateAll();
-		} catch (Exception e) {
-			if (validateArgs.verbose)
-				e.printStackTrace();
-			showError("Error while validating module", e.getMessage());
-			return 1;
+	@Override
+	public void run() {
+		// fallback when no subcommand is used
+		CommandLine.usage(this, System.out);
+	}
+
+	public static class Verbose {
+
+		@Option(
+				names = {"-v", "--verbose"},
+				description = "Show verbose output including stack traces when appropriate.",
+				defaultValue = "false"
+		)
+		boolean verbose;
+	}
+	
+	public static class ValidationArgs extends Verbose {
+		
+		// TODO UX this doesn't actually make much sense. I tried to summarize but the code
+		//         is kind of bonkers, just read the ModuleValidator constructor.
+		//         It should probably be removed.
+		//         Changing validate to take only one module made it somewhat less crazy
+		@Option(
+				paramLabel = "<method_store_url>",
+				names = {"-m", "--method_store"},
+				description = """
+						The URL of the KBase Narrative Method Store to use when validating method \
+						specifications.\
+						""",
+				defaultValue = ModuleBuilder.DEFAULT_METHOD_STORE_URL,
+				showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+		)
+		String methodStoreUrl;
+
+		// TODO UX seems like this could be removed, not sure it's still relevant.
+		//         just looks for a specific value in the spec.json file. Check w/ Bill
+		@Option(
+				names = {"-a", "--allow_sync_method"},
+				description = "Allow synchronous methods (advanced).",
+				defaultValue = "false"
+		)
+		boolean allowSyncMethods;
+	}
+
+	@Command(name = "validate", description = "Validate a module.")
+	public static class ValidateCommand extends ValidationArgs implements Callable<Integer> {
+
+		@Parameters(
+				paramLabel = "<module_path>",
+				description = "Path to  the module directory.",
+				arity = "0..1",
+				defaultValue = ".",
+				showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+		)
+		Path module;
+
+		@Override
+		public Integer call() {
+			try {
+				final ModuleValidator mv = new ModuleValidator(
+						module.toString(), verbose, methodStoreUrl, allowSyncMethods
+				);
+				return mv.validate();
+			} catch (Exception e) {
+				showError("Error while validating module", e.getMessage());
+				if (verbose) {
+					e.printStackTrace();
+				}
+				return 1;
+			}
 		}
 	}
 
 	/**
-	 * Runs the module initialization command - this creates a new module in the relative directory name given.
-	 * There's only a couple of possible arguments here in the initArgs:
-	 * userName (required) - the user's Github user name, used to set up some optional fields
-	 * moduleNames (required) - this catchall represents the module's name. Any whitespace (e.g. token breaks) 
-	 * are replaced with underscores. So if a user runs:
-	 *   kb-sdk init my new module
-	 * they get a module called "my_new_module" in a directory of the same name.
-	 * @param initArgs
-	 * @param jc
-	 * @return
+	 * Runs the module initialization command - this creates a new module in the relative
+	 * directory name given.
 	 */
-	private static int runInitCommand(InitCommandArgs initArgs, JCommander jc) {
-		// Figure out module name.
-		// Join together spaced out names with underscores if necessary.
-		if (initArgs.moduleNames == null || initArgs.moduleNames.size() == 0) {
-			ModuleBuilder.showError("Init Error", "A module name is required.");
-			return 1;
-		}
-		String moduleName = StringUtils.join(initArgs.moduleNames, "_");
+	@Command(name = "init", description = "Initialize a module in the current directory.")
+	public static class InitCommand extends Verbose implements Callable<Integer> {
+		
+		@Option(
+				paramLabel = "<user_name>",
+				names = {"-u", "--user"},
+				required = true,
+				description = "Provide a username to serve as the owner of this module."
+		)
+		String userName;
 
-		// Get username if available
-		String userName = null;
-		if (initArgs.userName != null)
-			userName = initArgs.userName;
+		@Option(
+				names = {"-e", "--example"},
+				description = """
+						Include a fully featured example in your module. \
+						This generates an example set of code and configurations.\
+						""",
+				defaultValue = "false"
+		)
+		boolean example;
+		
+		@Option(
+				names = {"-l", "--language"},
+				description =
+						"The language for the module. Valid values: ${COMPLETION-CANDIDATES}.",
+				defaultValue = "python",
+				showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+		)
+		Language language;
 
-		// Get chosen language
-		String language = ModuleInitializer.DEFAULT_LANGUAGE;
-		if (initArgs.language != null) {
-			language = initArgs.language;
-		}
-		try {
-			ModuleInitializer initer = new ModuleInitializer(moduleName, userName, language, initArgs.verbose);
-			initer.initialize(initArgs.example);
-		}
-		catch (Exception e) {
-			if (initArgs.verbose)
-				e.printStackTrace();
-			showError("Error while initializing module", e.getMessage());
-			return 1;
-		}
-		return 0;
-	}
+		@Parameters(
+				paramLabel = "<module_name>",
+				description = "The name of the module to create.",
+				arity = "1"
+		)
+		String moduleName;
 
-	public static int runCompileCommand(CompileCommandArgs a, JCommander jc) {
-		printVersion();
-		// Step 1: convert list of args to a  Files (this must be defined because it is required)
-		File specFile = null;
-		try {
-			if(a.specFileNames.size()>1) {
-				// right now we only support compiling one file at a time
-				ModuleBuilder.showError("Compile Error","Too many input KIDL spec files provided",
-						"Currently there is only support for compiling one module at a time, which \n"+
-								"is required to register data types and KIDL specs with the Workspace.  This \n"+
-								"code may be extended in the future to allow multiple modules to be compiled \n"+
-						"together from separate files into the same client/server.");
+		@Override
+		public Integer call() {
+			try {
+				final ModuleInitializer initer = new ModuleInitializer(
+						moduleName, userName, "" + language, verbose
+				);
+				initer.initialize(example);
+			}
+			catch (Exception e) {
+				showError("Error while initializing module", e.getMessage());
+				if (verbose) {
+					e.printStackTrace();
+				}
 				return 1;
 			}
-			List<File> specFiles = convertToFiles(a.specFileNames);
-			specFile = specFiles.get(0);
-		} catch (IOException | RuntimeException e) {
-			showError("Error accessing input KIDL spec file", e.getMessage());
-			if (a.verbose) {
-				e.printStackTrace();
-			}
-			return 1;
+			return 0;
 		}
+	}
+	
+	public static class ClientVersionsGroup {
+		@Option(
+				names = {"--clasyncver"},
+				description = """
+						Set the verion of code to run when making asynchronous calls via a \
+						client. Valid valus are a git commit hash or "dev", "beta", or "release". \
+						The targeted version must be registered in the KBase Catalog.\
+						"""
+		)
+		String clAsyncVer;
 
-		if (a.clAsyncVer != null && a.dynservVer != null) {
-			showError("Bad arguments",
-					"clasyncver and dynserver cannot both be specified");
-			return 1;
-		}
-
-		// Step 2: check or create the output directory
-		File outDir = a.outDir == null ? new File(".") : new File(a.outDir);
-		try {
-			outDir = outDir.getCanonicalFile();
-		} catch (IOException e) {
-			showError("Error accessing output directory", e.getMessage());
-			return 1;
-		}
-		if (!outDir.exists())
-			outDir.mkdirs();
-
-		// Step 3: validate the URL option if it is defined
-		if (a.url != null) {
-			try {
-				new URL(a.url);
-			} catch (MalformedURLException mue) {
-				showError("Compile Option error", "The provided url " + a.url + " is invalid.");
-				return 1;
-			}
-		}
-
-		// Step 4: info collection for status method
-		File moduleDir = specFile.getAbsoluteFile().getParentFile();
-		String semanticVersion = null;
-		try {
-			File kbaseYmlFile = new File(moduleDir, "kbase.yml");
-			if (kbaseYmlFile.exists()) {
-				String kbaseYml = TextUtils.readFileText(kbaseYmlFile);
-				@SuppressWarnings("unchecked")
-				Map<String,Object> kbaseYmlConfig = (Map<String, Object>)new Yaml().load(kbaseYml);
-				semanticVersion = (String)kbaseYmlConfig.get("module-version");
-			}
-		} catch (Exception ex) {
-			System.out.println("WARNING! Couldn't collect semantic version: " + ex.getMessage());
-		}
-		if (semanticVersion == null)
-			semanticVersion = "0.0.1";
-		String gitUrl = "";
-		String gitCommitHash = "";
-		if (new File(moduleDir, ".git").exists()) {
-			try {
-				gitUrl = getCmdOutput(moduleDir, "git", "config", "--get", "remote.origin.url");
-			} catch (Exception ex) {
-				System.out.println("WARNING! Couldn't collect git URL: " + ex.getMessage());
-			}
-			try {
-				gitCommitHash = getCmdOutput(moduleDir, "git", "rev-parse", "HEAD");
-			} catch (Exception ex) {
-				System.out.println("WARNING! Couldn't collect git commit hash: " + ex.getMessage());
-			}
-		}
-		try {
-			RunCompileCommand.generate(specFile, a.url, a.pyClientSide, a.pyClientName, 
-					a.pyServerSide, a.pyServerName, a.pyImplName, a.javaClientSide, 
-					a.javaServerSide, a.javaPackageParent, a.javaSrcDir, 
-					outDir, a.jsonSchema, a.clAsyncVer, a.dynservVer, a.html,
-					semanticVersion, gitUrl, gitCommitHash);
-		} catch (Throwable e) {
-			System.err.println("Error compiling KIDL specfication:");
-			System.err.println(e.getMessage());
-			if (a.verbose) {
-				e.printStackTrace();
-			}
-			return 1;
-		}
-		return 0;
+		@Option(
+				names = {"--dynservver"},
+				description = """
+						Set clients to be built for use with KBase dynamic services \
+						(e.g. with URL lookup via the Service Wizard) with the specified \
+						dynamic service version. \
+						Valid valus are a git commit hash or "dev", "beta", or "release". \
+						The targeted version must be registered in the KBase Catalog.\
+						"""
+		)
+		String dynservVer;
 	}
 
+	@Command(name = "compile", description = "Compile a KIDL file into client and server code.")
+	public static class CompileCommand extends Verbose implements Callable<Integer> {
+		
+		@Option(
+				names = {"--out"},
+				description = "Set the output folder name.",
+				defaultValue = ".",
+				showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+		)
+		Path out;
+
+		@Option(
+				names = {"--url"},
+				description =
+						"Set the default url for the target service in generated client code."
+		)
+		URL url;
+		
+		@Option(
+				names = {"--py"},
+				description = "Generate a Python client with a default name.",
+				defaultValue = "false"
+		)
+		boolean pyClientSide;
+		
+		@Option(
+				paramLabel = "<py_client_name>",
+				names = {"--pyclname"},
+				description = """
+						Generate a Python client with with the \
+						name provided, optionally prefixed by subdirectories separated by '.' \
+						as in the standard Python module syntax \
+						(e.g. biokbase.mymodule.client). Overrides the --py option.\
+						"""
+		)
+		String pyClientName;
+		
+		@Option(
+				names = {"--pyserv"},
+				// TODO PYCLI I don't think we actually want to generate clients by default.
+				//            I think I restored it to get tests to pass
+				description = """
+						Generate a Python server with a default name. \
+						If set, Python clients will also be generated.\
+						""",
+				defaultValue = "false"
+		)
+		boolean pyServerSide;
+		
+		@Option(
+				names = {"--pysrvname"},
+				paramLabel = "<py_server_name>",
+				description = """
+						Generate a Python server with the \
+						name provided, optionally prefixed by subdirectories separated by '.' \
+						as in the standard Python module syntax \
+						(e.g. biokbase.mymodule.server). Overrides the --pysrv option.\
+						"""
+		)
+		String pyServerName;
+		
+		@Option(
+				paramLabel = "<py_implementation_name>",
+				names = {"--pyimplname"},
+				// TODO PYCLI I don't think we actually want client generation by default
+				//            I think I restored it to get tests to pass
+				description = """
+						Generate a Python server implementation with the \
+						name provided, optionally prefixed by subdirectories separated by '.' \
+						as in the standard Python module syntax \
+						(e.g. biokbase.mymodule.impl). \
+						If set, Python server and client code will also be generated.\
+						"""
+		)
+		String pyImplName;
+
+		@Option(
+				paramLabel = "<java_source_dir>",
+				names = {"--javasrc"},
+				description = "Set the output folder for generated Java code.",
+				defaultValue = "src",
+				showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+		)
+		String javaSrcDir;
+		
+		@Option(
+				paramLabel = "<java_package>",
+				names = {"--javapackage"},
+				description = """
+						Set the Java package for generated code. Module subpackages are \
+						created in this package.\
+						""",
+				defaultValue = DEFAULT_PARENT_PACKAGE,
+				showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+		)
+		String javaPackageParent;
+		
+		@Option(
+				names = {"--java"},
+				description = "Generate Java client code in the directory set by --javasrc.",
+				defaultValue = "false"
+		)
+		boolean javaClientSide;
+		
+		@Option(
+				names = {"--javasrv"},
+				description = "Generate Java server code in the directory set by --javasrc.",
+				defaultValue = "false"
+		)
+		boolean javaServerSide;
+		
+		@Option(
+				paramLabel = "<json_schema_dir>",
+				names = {"--jsonschema"},
+				description = """
+					Generate JSON schema documents for the types in the output folder specified.\
+					"""
+		)
+		String jsonSchema;
+		
+		@ArgGroup(exclusive = true, multiplicity = "0..1")
+		final ClientVersionsGroup clientVersions = new ClientVersionsGroup();
+		
+		@Option(
+				names = {"--html"},
+				description = "Generate an HTML version of the input spec file.",
+				defaultValue = "false"
+		)
+		boolean html;
+		
+		@Parameters(
+				paramLabel = "<spec_file>",
+				description = "The KIDL specification file to process.",
+				arity = "1"
+		)
+		Path specFileName;
+
+		@Override
+		public Integer call() {
+			// TODO CODE this method is 100 lines, split it up (pretty basic though)
+			System.out.println(VERSION_INFO);
+			
+			final Path specFile = specFileName.toAbsolutePath();
+			if (!Files.exists(specFile) || !Files.isRegularFile(specFile)) {
+				showError(
+						"Error accessing input KIDL spec file",
+						"File does not exist or is not a regular file"
+				);
+				return 1;
+			}
+			
+			final Path outDir = out.toAbsolutePath();
+			try {
+				Files.createDirectories(outDir);
+			} catch (IOException e) {
+				showError("Error creating output directory", e.getMessage());
+				if (verbose) {
+					e.printStackTrace();
+				}
+				return 1;
+			}
+
+			final Path moduleDir = specFile.getParent();
+			String semanticVersion = null;
+			try {
+				// TODO CODE all these hardcoded file names should be constants somewhere
+				final Path kbaseYmlFile = moduleDir.resolve("kbase.yml");
+				if (Files.exists(kbaseYmlFile)) {
+					final String kbaseYml = TextUtils.readFileText(kbaseYmlFile.toFile());
+					@SuppressWarnings("unchecked")
+					final Map<String,Object> kbaseYmlConfig =
+						(Map<String, Object>) new Yaml().load(kbaseYml);
+					semanticVersion = (String) kbaseYmlConfig.get("module-version");
+				}
+			} catch (Exception ex) {
+				System.out.println(
+						"WARNING! Couldn't collect semantic version: " + ex.getMessage()
+				);
+			}
+			if (semanticVersion == null) {
+				semanticVersion = "0.1.0";
+			}
+			String gitUrl = "";
+			String gitCommitHash = "";
+			if (Files.exists(moduleDir.resolve(".git"))) {
+				try {
+					gitUrl = getCmdOutput(
+							moduleDir.toFile(), "git", "config", "--get", "remote.origin.url"
+					);
+				} catch (Exception ex) {
+					System.out.println("WARNING! Couldn't collect git URL: " + ex.getMessage());
+				}
+				try {
+					gitCommitHash = getCmdOutput(moduleDir.toFile(), "git", "rev-parse", "HEAD");
+				} catch (Exception ex) {
+					System.out.println(
+							"WARNING! Couldn't collect git commit hash: " + ex.getMessage()
+					);
+				}
+			}
+			try {
+				// TODO CODE start using Path instead of File
+				// TODO CODE this needs a freakin builder
+				RunCompileCommand.generate(
+						specFile.toFile(),
+						url,
+						pyClientSide,
+						pyClientName, 
+						pyServerSide,
+						pyServerName,
+						pyImplName,
+						javaClientSide, 
+						javaServerSide,
+						javaPackageParent,
+						javaSrcDir,
+						outDir.toFile(),
+						jsonSchema,
+						clientVersions.clAsyncVer,
+						clientVersions.dynservVer,
+						html,
+						semanticVersion,
+						gitUrl,
+						gitCommitHash
+				);
+			} catch (Throwable e) {
+				showError("Error compiling KIDL specfication:", e.getMessage());
+				if (verbose) {
+					e.printStackTrace();
+				}
+				return 1;
+			}
+			return 0;
+		}
+	}
+	
+	
 	private static String getCmdOutput(File workDir, String... cmd) throws Exception {
-		StringWriter sw = new StringWriter();
-		PrintWriter pw = new PrintWriter(sw);
+		final StringWriter sw = new StringWriter();
+		final PrintWriter pw = new PrintWriter(sw);
 		ProcessHelper.cmd(cmd).exec(workDir, null, pw);
 		return sw.toString().trim();
 	}
 
-	static List<File> convertToFiles(List<String> filenames) throws IOException {
-		List <File> files = new ArrayList<File>(filenames.size());
-		for(String filename: filenames) {
-			File f = new File(filename);
-			if(!f.exists()) {
-				throw new IOException("KIDL file \""+filename+"\" does not exist");
-			}
-			files.add(f);
-		}
-		return files;
-	}
-
-	public static class GlobalArgs {
-		@Parameter(names = {"-h","--help"}, help = true, description="Display help and full usage information.")
-		boolean help;
-	}
-
 	/**
-	 * Runs the module test command - this runs tests in local docker container.
-	 * @param testArgs
-	 * @param jc
-	 * @return
+	 * Runs the module test command - this runs tests in a local docker container.
 	 */
-	private static int runTestCommand(TestCommandArgs testArgs, JCommander jc) {
-		// Figure out module name.
-		// Join together spaced out names with underscores if necessary.
-		int returnCode = 1;
-
-		try {
-			ModuleTester tester = new ModuleTester();
-			returnCode = tester.runTests(testArgs.methodStoreUrl, testArgs.skipValidation, testArgs.allowSyncMethods);
-		}
-		catch (Exception e) {
-			if (testArgs.verbose)
-				e.printStackTrace();
-			showError("Error while testing module", e.getMessage());
-			return returnCode;
-		}
-
-		return returnCode;
-	}
-
-	private static void printVersion() {
-		System.out.println("KBase SDK version " + VERSION + " (commit " + GitCommit.COMMIT + ")");
-	}
-
-	private static int runVersionCommand(VersionCommandArgs testArgs, JCommander jc) {
-		printVersion();
-		return 0;
-	}
-
-	private static int runInstallCommand(InstallCommandArgs installArgs, JCommander jc) {
-		if (installArgs.moduleName == null || installArgs.moduleName.size() != 1) {
-			ModuleBuilder.showError("Command Line Argument Error", 
-					"One and only one module name should be provided");
-			return 1;
-		}
-		try {
-			return new ClientInstaller().install(installArgs.lang, installArgs.async,
-					installArgs.core || installArgs.sync, installArgs.dynamic, 
-					installArgs.tagVer, installArgs.verbose, installArgs.moduleName.get(0), 
-					null, installArgs.clientName);
-		} catch (Exception e) {
-			if (installArgs.verbose)
-				e.printStackTrace();
-			showError("Error while installing client", e.getMessage());
-			return 1;
-		}
-	}
-
-	private static int runRunCommand(RunCommandArgs runArgs, JCommander jc) {
-		if (runArgs.methodName == null || runArgs.methodName.size() != 1) {
-			ModuleBuilder.showError("Command Line Argument Error", 
-					"One and only one method name should be provided");
-			return 1;
-		}
-		try {
-			if (runArgs.inputFile == null && runArgs.inputJson == null && !runArgs.stdin)
-				throw new IllegalStateException("No one input method is used " +
-						"(should be one of '-i', '-j' or '-s')");
-			return new ModuleRunner(runArgs.sdkHome).run(runArgs.methodName.get(0), 
-					runArgs.inputFile, runArgs.stdin, runArgs.inputJson, runArgs.output, 
-					runArgs.tagVer, runArgs.verbose, runArgs.keepTempFiles, runArgs.provRefs, 
-					runArgs.mountPoints);
-		} catch (Exception e) {
-			if (runArgs.verbose)
-				e.printStackTrace();
-			showError("Error while installing client", e.getMessage());
-			return 1;
-		}
-	}
-
-	@Parameters(commandDescription = "Validate a module or modules.")
-	private static class ValidateCommandArgs {
-		@Parameter(names={"-v","--verbose"}, description="Show verbose output")
-		boolean verbose = false;
-
-		@Parameter(names={"-m", "--method_store"}, description="Narrative Method Store URL " +
-				"(default is " + DEFAULT_METHOD_STORE_URL + ")")
-		String methodStoreUrl = DEFAULT_METHOD_STORE_URL;
-
-		@Parameter(names={"-a","--allow_sync_method"}, description="Allow synchonous methods " +
-				"(advanced option, default is false)")
-		boolean allowSyncMethods = false;
-
-		@Parameter(description="[path to the module directories]")
-		List<String> modules;
-	}
-
-	@Parameters(commandDescription = "Initialize a module in the current directory.")
-	private static class InitCommandArgs {
-		@Parameter(names={"-v","--verbose"}, description="Show verbose output")
-		boolean verbose = false;
-
-		@Parameter(required=true, names={"-u","--user"}, 
-				description="(Required) provide a username to serve as the owner of this module")
-		String userName;
-
-		@Parameter(names={"-e","--example"}, 
-				description="Include a fully featured example in your module. " +
-						"This generates an example set of code and configurations that can " +
-				"be used to demonstrate a very simple example.")
-		boolean example = false;
-
-		@Parameter(names={"-l","--language"}, description="Choose a language for developing " + 
-				" code in your module. You can currently choose from Python and Java " + 
-				"(default=Python)")
-		String language = ModuleInitializer.DEFAULT_LANGUAGE;
-
-		@Parameter(required=true, description="<module name>")
-		List<String> moduleNames;
-	}
-
-
-	@Parameters(commandDescription = "Get help and usage information.")
-	private static class HelpCommandArgs {
-		@Parameter(description="Show usage for this command")
-		List<String> command;
-		@Parameter(names={"-a","--all"}, description="Show usage for all commands")
-		boolean showAll = false;
-	}
-
-	@Parameters(commandDescription = "Compile a KIDL file into client and server code")
-	public static class CompileCommandArgs {
-
-		@Parameter(names="--out",description="Set the output folder name (default is the current directory)")
-		//, metaVar="<out-dir>")
-		String outDir = null;
-
-		@Parameter(names="--py", description="Generate a Python client with a standard default name")
-		boolean pyClientSide = false;
-
-		@Parameter(names="--pyclname", description="Generate a Python client with with the " +
-				"name provided, optionally prefixed by subdirectories separated by '.' as "+
-				"in the standard Python module syntax (e.g. biokbase.mymodule.client,"+
-				"overrides the --py option).")//, metaVar = "<py-client-name>")
-		String pyClientName = null;
-
-		@Parameter(names="--pysrv", description="Generate a Python server with a " +
-				"standard default name.  If set, Python clients will automatically be generated too.")
-		boolean pyServerSide = false;
-
-		@Parameter(names="--pysrvname", description="Generate a Python server with the " +
-				"name provided, optionally prefixed by subdirectories separated by '.' as "+
-				"in the standard Python module syntax (e.g. biokbase.mymodule.server,"+
-				"overrides the --pysrv option).")//, metaVar = "<py-server-name>")
-		String pyServerName = null;
-
-		@Parameter(names="--pyimplname", description="Generate a Python server implementation with the " +
-				"name provided, optionally prefixed by subdirectories separated by '.' as "+
-				"in the standard Python module syntax (e.g. biokbase.mymodule.impl)." +
-				" If set, Python server and client code will be generated too.")//, metaVar = "<py-impl-name>")
-		String pyImplName = null;
-
-		@Parameter(names="--java", description="Generate Java client code in the directory set by --javasrc")
-		boolean javaClientSide = false;
-
-		@Parameter(names="--javasrc",description="Set the output folder for generated Java code")//, metaVar = 
-		//"<java-src-dir>")
-		String javaSrcDir = "src";
-
-		@Parameter(names="--url", description="Set the default url for the service in generated client code")//, metaVar = "<url>")
-		String url = null;
-
-		@Parameter(names="--javapackage",description="Set the Java package for generated code (module subpackages are " +
-				"created in this package), default value is " + defaultParentPackage)//, 
-		//metaVar = "<java-package>")      
-		String javaPackageParent = defaultParentPackage;
-
-		@Parameter(names="--javasrv", description="Generate Java server code in the directory set by --javasrc")
-		boolean javaServerSide = false;
-
-		@Parameter(names="--jsonschema",description="Generate JSON schema documents for the types in the output folder specified.")//, metaVar="<json-schema>")
-		String jsonSchema = null;
-
-		@Parameter(names="--clasyncver",description="Will set in client code version of service for asyncronous calls " +
-				"(it could be git commit hash of version registered in catalog or one of version tags: dev/beta/release)")
-		String clAsyncVer = null;
-
-		@Parameter(names="--dynservver", description="Clients will be built " +
-				"for use with KBase dynamic services (e.g. with URL lookup " +
-				"via the Service Wizard) with the specified version " +
-				"(git commit hash or dev/beta/release)." +
-				"clasyncver may not be specified if " +
-				"dynservver is specified.")
-		String dynservVer = null;
-
-		@Parameter(names="--html", description="Generate HTML version(s) of " +
-				"the input spec file(s)")
-		boolean html = false;
-
-		@Parameter(names={"-v", "--verbose"}, description="Print full stack " +
-				"trace on a compile failure")
-		boolean verbose = false;
-
-		@Parameter(required=true, description="<KIDL spec file>")
-		List <String> specFileNames;
-	}
-
-	@Parameters(commandDescription = "Test a module with local Docker.")
-	private static class TestCommandArgs {
-		@Parameter(names={"-m", "--method_store"}, description="Narrative Method Store URL used in validation " +
-				"(default is " + DEFAULT_METHOD_STORE_URL + ")")
-		String methodStoreUrl = DEFAULT_METHOD_STORE_URL;
-
-		@Parameter(names={"-s", "--skip_validation"}, description="Will skip validation step (default is false)")
-		boolean skipValidation = false;
-
-		@Parameter(names={"-a","--allow_sync_method"}, description="Allow synchonous methods " +
-				"(advanced option, part of validation settings, default value is false)")
-		boolean allowSyncMethods = false;
-
-		@Parameter(names={"-v","--verbose"}, description="Print more details including error stack traces")
-		boolean verbose = false;
-	}
-
-	@Parameters(commandDescription = "Print current version of kb-sdk.")
-	private static class VersionCommandArgs {
-	}
-
-	@Parameters(commandDescription = "Install a client for KBase module.")
-	private static class InstallCommandArgs {
-		@Parameter(names={"-l", "--language"}, description="Language of generated client code " +
-				"(default is one defined in kbase.yml)")
-		String lang;
-
-		@Parameter(names={"-a", "--async"}, description="Force generation of asynchronous calls " +
-				"(default is chosen based on information registered in catalog)")
-		boolean async = false;
-
-		@Parameter(names={"-s", "--sync"}, description="Depricated flag, means the same as -c (--core)")
-		boolean sync = false;
-
-		@Parameter(names={"-c", "--core"}, description="Force generation of calls to core service" +
-				"(WARNING: please use it only for core services not registered in catalog)")
-		boolean core = false;
-
-		@Parameter(names={"-d", "--dynamic"}, description="Force generation of dynamic service calls" +
-				"(default is chosen based on information registered in catalog)")
-		boolean dynamic = false;
-
-		@Parameter(names={"-t","--tag-or-ver"}, description="Tag or version " +
-				"(default is chosen based on information registered in catalog)")
-		String tagVer = null;
-
-		@Parameter(names={"-v","--verbose"}, description="Print more details including error stack traces")
-		boolean verbose = false;
-
-		@Parameter(names={"-n","--clientname"}, description="Optional parameter defining custom client name " +
-				"(default is module name)")
-		String clientName = null;
-
-		@Parameter(required=true, description="<module name or path/URL to spec-file>")
-		List<String> moduleName;
-	}
-
-	@Parameters(commandDescription = "Run a method of registered KBase module locally.")
-	private static class RunCommandArgs {
-		@Parameter(names={"-i", "--input"}, description="Input JSON file " +
-				"(optional, if not set -s or -j should be used)")
-		File inputFile = null;
-
-		@Parameter(names={"-s","--stdin"}, description="Flag for reading input data from STDIN " +
-				"(default is false, used if neither -i or -j is set)")
-		boolean stdin = false;
-
-		@Parameter(names={"-j","--json"}, description="Input JSON string " +
-				"(optional, if not set -s or -i should be used)")
-		String inputJson = null;
-
-		@Parameter(names={"-o", "--output"}, description="Output JSON file " +
-				"(optional, if not set output will be printed to STDOUT)")
-		File output = null;
-
-		@Parameter(names={"-t","--tag-or-ver"}, description="Tag or version " +
-				"(default is chosen based on information registered in catalog)")
-		String tagVer = null;
-
-		@Parameter(names={"-v","--verbose"}, description="Print more details including error " +
-				"stack traces")
-		boolean verbose = false;
-
-		@Parameter(names={"-k","--keep-tmp"}, description="Keep temporary files/folders at the " +
-				"end (default value is false)")
-		boolean keepTempFiles = false;
-
-		@Parameter(names={"-h","--sdk-home"}, description="Home folder of kb-sdk where sdk.cfg " +
-				"file and run_local folder are expected to be found or created if absent " +
-				"(default path is loaded from 'KB_SDK_HOME' system environment variable)")
-		String sdkHome = null;
-
-		@Parameter(names={"-r","--prov-refs"}, description="Optional comma-separated list of " +
-				"references workspace objects that will be refered from provenance")
-		String provRefs = null;
-
-		@Parameter(names={"-m","--mount-points"}, description="Optional comma-separated list of " +
-				"mount point pairs for docker container (this parameter contains of local folder" +
-				" and inner folder separated by ':', local folder points to place in local file " +
-				"system, inner folder appears inside docker container, if inner path is not " +
-				"absolute it's treated as relative to /kb/module/work folder; if some mount " +
-				"point path doesn't have ':' and inner part then it appears as " +
-				"/kb/module/work/tmp inside docker)")
-		String mountPoints = null;
-
-		@Parameter(required=true, description="<fully qualified method name " +
-				"(with SDK module prefix followed by '.')>")
-		List<String> methodName;
-	}
-
-	private static void showBriefHelp(JCommander jc, PrintStream out) {
-		Map<String,JCommander> commands = jc.getCommands();
-		out.println("");
-		out.println(MODULE_BUILDER_SH_NAME + " - a developer tool for building and validating KBase modules");
-		out.println("");
-		out.println("usage: "+MODULE_BUILDER_SH_NAME+" <command> [options]");
-		out.println("");
-		out.println("    The available commands are:");
-		for (Map.Entry<String, JCommander> command : commands.entrySet()) {
-			out.println("        " + command.getKey() +" - "+jc.getCommandDescription(command.getKey()));
-		}
-		out.println("");
-		out.println("    For help on a specific command, see \"kb-sdk help <command>\".");
-		out.println("    For full usage information, see \"kb-sdk help -a\".");
-		out.println("");
-	};
-
-	private static void showCommandUsage(JCommander jc, HelpCommandArgs helpArgs, PrintStream out) {
-		if(helpArgs.showAll) {
-			showFullUsage(jc, out);
-		} else if(helpArgs.command !=null && helpArgs.command.size()>0) {
-			String indent = "";
-			StringBuilder usage = new StringBuilder();
-			for(String cmd:helpArgs.command) {
-				if(jc.getCommands().containsKey(cmd)) {
-					usage.append(MODULE_BUILDER_SH_NAME + " "+cmd+"\n");
-					jc.usage(cmd,usage,indent+"    ");
-					usage.append("\n");
-				} else {
-					out.println("Command \""+cmd+"\" is not a valid command.  To view available commands, run:");
-					out.println("    "+MODULE_BUILDER_SH_NAME+" "+HELP_COMMAND);
-					return;
-				}
+	@Command(name = "test", description = "Test a module with local Docker.")
+	public static class TestCommand extends ValidationArgs implements Callable<Integer> {
+		
+		@Option(
+				names = {"-s", "--skip_validation"},
+				description = "Skip module validation.",
+				defaultValue = "false"
+		)
+		boolean skipValidation;
+		
+		@Override
+		public Integer call() {
+			try {
+				final ModuleTester tester = new ModuleTester();
+				return tester.runTests(methodStoreUrl, skipValidation, allowSyncMethods);
 			}
-			out.print(usage.toString());
-		} else {
-			showBriefHelp(jc, out);
+			catch (Exception e) {
+				showError("Error while initializing module", e.getMessage());
+				if (verbose) {
+					e.printStackTrace();
+				}
+				return 1;
+			}
 		}
-	};
-
-	private static void showFullUsage(JCommander jc, PrintStream out) {
-		String indent = "";
-		StringBuilder usage = new StringBuilder();
-		jc.usage(usage,indent);
-		out.print(usage.toString());
-	};
-
-
-	private static void showError(String error, String message, String extraHelp) {
-		System.err.println(error + ": " + message+"\n");
-		if(!extraHelp.isEmpty())
-			System.err.println(extraHelp+"\n");
-		System.err.println("For more help and usage information, run:");
-		System.err.println("    "+MODULE_BUILDER_SH_NAME+" "+HELP_COMMAND);
-		System.err.println("");
 	}
-
-	private static void showError(String error, String message) {
-		showError(error,message,"");
+	
+	public static class TagAndVerbose extends Verbose {
+		
+		@Option(
+				paramLabel = "<tag_or_version>",
+				names = {"-t", "--tag-or-ver"},
+				description = """
+						Set the version of the module to run on a call - \
+						one of the "dev", "beta", or "release" tags or a git hash. \
+						The targeted version must be registered in the KBase Catalog. \
+						The default is based on the latest release in the KBase Catalog.\
+						"""
+		)
+		String tagVer;
 	}
+	
+	@Command(name = "install", description = "Install a client for a KBase module.")
+	public static class InstallCommand extends TagAndVerbose implements Callable<Integer> {
+		
+		@Option(
+				names = {"-l", "--language"},
+				description = """
+						Language for the generated client. Defaults to the module langage. \
+						Valid values: ${COMPLETION-CANDIDATES}.\
+						"""
+		)
+		Language language;
+		
+		@Option(
+				names = {"-a", "--async"},
+				description = """
+						Force generation of asynchronous calls. Default is the KBase Catalog \
+						setting for the module.\
+						""",
+				defaultValue = "false"
+		)
+		boolean async;
+		
+		@Option(
+				names = {"-c", "--core"},
+				description = """
+						Force generation of synchronous calls for KBase core services. \
+						In almost all cases specifying this argument is a mistake.\
+						""",
+				defaultValue = "false"
+		)
+		boolean core;
+		
+		@Option(
+				names = {"-d", "--dynamic"},
+				description = """
+						Force generation of dynamic service calls. Default is the KBase Catalog \
+						setting for the module.\
+						""",
+				defaultValue = "false"
+		)
+		boolean dynamic;
+		
+		@Option(
+				paramLabel = "<client_name>",
+				names = {"-n", "--clientname"},
+				description = """
+						Set a custom name for the client. The default is the module name.\
+						"""
+		)
+		String clientName;
+		
+		@Parameters(
+				paramLabel = "<module_name_or_path_or_url>",
+				description = """
+						Either the module name of the client to install, or a file path or URL \
+						to a KIDL spec for the client to install.\
+						""",
+				arity = "1"
+		)
+		String moduleName;
 
+		@Override
+		public Integer call() {
+			try {
+				return new ClientInstaller().install(
+						language == null ? null: language.toString(),
+						async,
+						core,
+						dynamic, 
+						tagVer,
+						verbose,
+						moduleName,
+						null,       // libDirName
+						clientName
+				);
+			} catch (Exception e) {
+				showError("Error while installing client", e.getMessage());
+				if (verbose) {
+					e.printStackTrace();
+				}
+				return 1;
+			}
+		}
+	}
+	
+	public static class RunInput {
+		@Option(
+				paramLabel = "<input_file>",
+				names = {"-i", "--input"},
+				description = "The JSON file containing the input for the method to run."
+		)
+		Path inputFile;
+		
+		@Option(
+				names = {"-s", "--stdin"},
+				description = "Read the JSON input for the method from STDIN.",
+				defaultValue = "false"
+		)
+		boolean stdin;
+		
+		@Option(
+				paramLabel = "<input_json>",
+				names = {"-j", "--json"},
+				description = "A JSON string containing the input for the method to run."
+		)
+		String inputJson;
+	}
+	
+	@Command(
+			name = "run",
+			description = "Run a method of an SDK module registered in the KBase catalog locally."
+	)
+	public static class RunCommand extends TagAndVerbose implements Callable<Integer> {
+		
+		@ArgGroup(exclusive = true, multiplicity = "1")
+		final RunInput input = new RunInput();
+		
+		@Option(
+				paramLabel = "<output_file>",
+				names = {"-o", "--output"},
+				description = """
+						The file where output should be written. If unspecified, output is \
+						written to STDOUT.\
+						"""
+		)
+		Path output;
+		
+		@Option(
+				names = {"-k", "--keep-tmp"},
+				description = "Keep temporary files from the run rather than deleting them.",
+				defaultValue = "false"
+		)
+		boolean keepTempFiles;
+		
+		@Option(
+				paramLabel = "<sdk_home_dir>",
+				names = {"-h", "--sdk-home"},
+				description = """
+						The folder containing the sdk.cfg and run_local folders. If they do \
+						not exist, they will be created. The default is loaded from the \
+						KB_SDK_HOME environment variable, which must be set if this \
+						argument is not supplied.\
+						"""
+		)
+		Path sdkHome;
+		
+		@Option(
+				paramLabel = "<provenance_references>",
+				names = {"-r","--prov-refs"},
+				description = """
+						A comma separated list of KBase workspace object addresses in the format \
+						<numerical workspace ID>/<numerical object ID/<version>. \
+						They will be included in the provenance of any saved workspace objects.\
+						"""
+		)
+		String provRefs;
+
+		@Option(
+				paramLabel = "<mount_points>",
+				names = {"-m","--mount-points"},
+				description = """
+						A comma separated list of mount points for the docker container. \
+						Each mount point consists of a local file path, a colon (:) separator, \
+						and a file path inside the docker container that is the target of the \
+						local mount. A relative docker container path is treated as relative to \
+						/kb/module/work. If the colon separator and docker container path are \
+						omitted the local path is mounted to /kb/module/work/tmp.\
+						"""
+		)
+		String mountPoints;
+
+		@Parameters(
+				paramLabel = "<method_name>",
+				description = """
+						The fully qualified name of the method to run, e.g.
+						"module_name.method_name".
+						""",
+				arity = "1"
+		)
+		String methodName;
+
+		@Override
+		public Integer call() {
+			try {
+				return new ModuleRunner(sdkHome == null ? null : sdkHome.toString()).run(
+						methodName,
+						input.inputFile == null ? null : input.inputFile.toFile(),
+						input.stdin,
+						input.inputJson,
+						output == null ? null : output.toFile(), 
+						tagVer,
+						verbose,
+						keepTempFiles,
+						provRefs, 
+						mountPoints
+				);
+			} catch (Exception e) {
+				showError("Error while running method", e.getMessage());
+				if (verbose) {
+					e.printStackTrace();
+				}
+				return 1;
+			}
+		}
+	}
+	
+	@Command(name = "version", description = "Print the program version and exit.")
+	public static class VersionCommand implements Callable<Integer> {
+		
+		// could add some different args for more parseable formats (e.g. JSON)
+		
+		@Override
+		public Integer call() {
+			System.out.println(VERSION_INFO);
+			return 0;
+		}
+	}
+	
+	private static void showError(final String error, final String message) {
+		System.err.println(error + ": " + message + "\n");
+	}
 }

--- a/src/main/java/us/kbase/mobu/compiler/RunCompileCommand.java
+++ b/src/main/java/us/kbase/mobu/compiler/RunCompileCommand.java
@@ -34,7 +34,7 @@ public class RunCompileCommand {
     public static void generate(
             // this is repulsive and needs a builder
             final File specFile,
-            final String url,
+            final URL url,
             final boolean pyClientSide, 
             final String pyClientName,
             boolean pyServerSide,
@@ -53,8 +53,10 @@ public class RunCompileCommand {
             final String gitUrl,
             final String gitCommitHash
             ) throws Exception {
-    	
+        // TODO CODE this looks similar to code in the client installer, might be duplicated
         FileSaver javaSrcDir = null;
+        // TODO CODE make javasrc path required if java processing is requested. Make a builder
+        //           Later spots in the code expect a non-null value for javaSrcDir
         if (javaSrcPath != null)
             javaSrcDir = new DiskFileSaver(correctRelativePath(javaSrcPath, outDir));
         final File dir = specFile.getCanonicalFile().getParentFile();
@@ -127,11 +129,11 @@ public class RunCompileCommand {
         if (javaClientSide) {
             //TODO DYNSERV add dynamic service client generation to all clients except Python
             javaParsingData = JavaTypeGenerator.processSpec(services, javaSrcDir, 
-                    javaPackageParent, javaServerSide, 
-                    url == null ? null : new URL(url),
+                    javaPackageParent, javaServerSide, url,
                     clientAsyncVer, dynservVer, semanticVersion, gitUrl, gitCommitHash);
         }
-        TemplateBasedGenerator.generate(services, url, pyClientSide, pyClientName, 
+        TemplateBasedGenerator.generate(services, url == null ? null : url.toString(),
+                pyClientSide, pyClientName, 
                 pyServerSide, pyServerName, pyImplName, ip, output, clientAsyncVer,
                 dynservVer, semanticVersion, gitUrl, gitCommitHash);
         String reportFile = System.getenv("KB_SDK_COMPILE_REPORT_FILE");

--- a/src/main/java/us/kbase/mobu/initializer/ModuleInitializer.java
+++ b/src/main/java/us/kbase/mobu/initializer/ModuleInitializer.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import us.kbase.mobu.Language;
 import us.kbase.mobu.compiler.JavaData;
 import us.kbase.mobu.compiler.JavaModule;
 import us.kbase.mobu.compiler.JavaTypeGenerator;
@@ -17,7 +18,7 @@ import us.kbase.mobu.installer.ClientInstaller;
 import us.kbase.templates.TemplateFormatter;
 
 public class ModuleInitializer {
-	public static final String DEFAULT_LANGUAGE = "python";
+	public static final String DEFAULT_LANGUAGE = "" + Language.python;
 
 	private final String moduleName;
 	private final String userName;

--- a/src/main/java/us/kbase/mobu/runner/ModuleRunner.java
+++ b/src/main/java/us/kbase/mobu/runner/ModuleRunner.java
@@ -68,14 +68,17 @@ public class ModuleRunner {
         File sdkCfgFile = new File(sdkHomeDir, "sdk.cfg");
         String sdkCfgPath = sdkCfgFile.getCanonicalPath();
         if (!sdkCfgFile.exists()) {
-            System.out.println("Warning: file " + sdkCfgFile.getAbsolutePath() + " will be " +
-                    "initialized (with 'kbase_endpoint'/'catalog_url' pointing to AppDev " +
-                    "environment, user and password will be prompted every time if not set)");
+            System.out.println("Warning: file " + sdkCfgFile.getAbsolutePath() + " will be "
+                    + "initialized (with 'kbase_endpoint'/'catalog_url'/'auth_service_url' "
+                    + "pointing to the AppDev environment). You will need to add your KBase "
+                    + "developer token to the file before running a method");
+            // TODO CODE client installer also writes the SDK config, plus several places in tests
             FileUtils.writeLines(sdkCfgFile, Arrays.asList(
                     "kbase_endpoint=https://appdev.kbase.us/services",
                     "catalog_url=https://appdev.kbase.us/services/catalog",
-                    "user=",
-                    "password=",
+                    "auth_service_url=https://appdev.kbase.us/services/auth/api/legacy/"
+                    + "KBase/Sessions/Login",
+                    "token=",
                     "### Please use next parameter to specify custom list of network",
                     "### interfaces used for callback IP address lookup:",
                     "#callback_networks=docker0,vboxnet0,vboxnet1,en0,en1,en2,en3"));

--- a/src/main/java/us/kbase/mobu/tester/ModuleTester.java
+++ b/src/main/java/us/kbase/mobu/tester/ModuleTester.java
@@ -87,16 +87,20 @@ public class ModuleTester {
     
     public int runTests(String methodStoreUrl, boolean skipValidation, boolean allowSyncMethods)
             throws Exception {
+        // TODO CODE some of this code looks simnilar to that in the module runner, DRY possible
         if (skipValidation) {
             System.out.println("Validation step is skipped");
         } else {
-            ModuleValidator mv = new ModuleValidator(Arrays.asList(moduleDir.getCanonicalPath()), 
-                    false, methodStoreUrl, allowSyncMethods);
-            int returnCode = mv.validateAll();
+            ModuleValidator mv = new ModuleValidator(
+                    moduleDir.getCanonicalPath(), false, methodStoreUrl, allowSyncMethods
+            );
+            int returnCode = mv.validate();
             if (returnCode!=0) {
                 System.out.println("You can skip validation step using -s (or --skip_validation)" +
                 		" flag");
-                System.exit(returnCode);
+                // TODO CODE should be throwing exceptions, not returning return codes all over the
+                //           place
+                return returnCode;
             }
         }
         String testLocal = "test_local";

--- a/src/main/resources/us/kbase/templates/module_makefile.vm.properties
+++ b/src/main/resources/us/kbase/templates/module_makefile.vm.properties
@@ -28,7 +28,7 @@ default: compile
 all: compile build build-startup-script build-executable-script build-test-script
 
 compile:
-	kb-sdk compile $(SPEC_FILE) \
+	kb-sdk compile -v $(SPEC_FILE) \
 		--out $(LIB_DIR) \
 #if($language == "python")
 		--pyclname $(SERVICE_CAPS).$(SERVICE_CAPS)Client \


### PR DESCRIPTION
Pretty much a rewrite of ModuleBuilder, not only because of the differences in how Picocli deals with arguments and methods, but also quite a bit of the code can be removed and handled with Picocli annotations.

* Enables built in shell completion, will be able to remove the handwritten shell completion file in a future PR
* Has built in support for GraalVM native compilation

Backwards incompatibilities:

* kb-sdk validate now only validates one module
* kb-sdk init will no longer concatenate multiple arguments into a single module name
* kb-sdk help no longer has an option to list help for all commands
* Picocli likely has other differences from JCommander. One I've found is that if an argument to a flag looks like a flag as well, Picocli will report an error

Bugfixes:

* Updated kb-sdk run to be compatible with auth2.
* Removed System.exit() calls other than in ModuleBuilder.main()