### PR TITLE
Remove `--method_store` and `--allow_sync_method` args from `test` and `valiate`

### DIFF
--- a/src/main/java/us/kbase/sdk/ModuleBuilder.java
+++ b/src/main/java/us/kbase/sdk/ModuleBuilder.java
@@ -78,20 +78,8 @@ public class ModuleBuilder implements Runnable{
 		boolean verbose;
 	}
 	
-	public static class ValidationArgs extends Verbose {
-		
-		// TODO UX seems like this could be removed, not sure it's still relevant.
-		//         just looks for a specific value in the spec.json file. Check w/ Bill
-		@Option(
-				names = {"-a", "--allow_sync_method"},
-				description = "Allow synchronous methods (advanced).",
-				defaultValue = "false"
-		)
-		boolean allowSyncMethods;
-	}
-
 	@Command(name = "validate", description = "Validate a module.")
-	public static class ValidateCommand extends ValidationArgs implements Callable<Integer> {
+	public static class ValidateCommand extends Verbose implements Callable<Integer> {
 
 		@Parameters(
 				paramLabel = "<module_path>",
@@ -105,9 +93,7 @@ public class ModuleBuilder implements Runnable{
 		@Override
 		public Integer call() {
 			try {
-				final ModuleValidator mv = new ModuleValidator(
-						module.toString(), verbose, allowSyncMethods
-				);
+				final ModuleValidator mv = new ModuleValidator(module.toString(), verbose);
 				return mv.validate();
 			} catch (Exception e) {
 				showError("Error while validating module", e.getMessage());
@@ -450,7 +436,7 @@ public class ModuleBuilder implements Runnable{
 	 * Runs the module test command - this runs tests in a local docker container.
 	 */
 	@Command(name = "test", description = "Test a module with local Docker.")
-	public static class TestCommand extends ValidationArgs implements Callable<Integer> {
+	public static class TestCommand extends Verbose implements Callable<Integer> {
 		
 		@Option(
 				names = {"-s", "--skip_validation"},
@@ -463,7 +449,7 @@ public class ModuleBuilder implements Runnable{
 		public Integer call() {
 			try {
 				final ModuleTester tester = new ModuleTester();
-				return tester.runTests(skipValidation, allowSyncMethods);
+				return tester.runTests(skipValidation);
 			}
 			catch (Exception e) {
 				showError("Error while initializing module", e.getMessage());

--- a/src/main/java/us/kbase/sdk/tester/ModuleTester.java
+++ b/src/main/java/us/kbase/sdk/tester/ModuleTester.java
@@ -85,15 +85,12 @@ public class ModuleTester {
         }
     }
     
-    public int runTests(final boolean skipValidation, final boolean allowSyncMethods)
-            throws Exception {
+    public int runTests(final boolean skipValidation) throws Exception {
         // TODO CODE some of this code looks similar to that in the module runner, DRY possible
         if (skipValidation) {
             System.out.println("Validation step is skipped");
         } else {
-            ModuleValidator mv = new ModuleValidator(
-                    moduleDir.getCanonicalPath(), false, allowSyncMethods
-            );
+            ModuleValidator mv = new ModuleValidator(moduleDir.getCanonicalPath(), false);
             int returnCode = mv.validate();
             if (returnCode!=0) {
                 System.out.println("You can skip validation step using -s (or --skip_validation)" +

--- a/src/main/java/us/kbase/sdk/validator/ModuleValidator.java
+++ b/src/main/java/us/kbase/sdk/validator/ModuleValidator.java
@@ -48,13 +48,8 @@ public class ModuleValidator {
 	protected String modulePath;
 	protected boolean verbose;
 	protected String methodStoreUrl;
-	protected boolean allowSyncMethods;
 
-	public ModuleValidator(
-			final String modulePath,
-			final boolean verbose, 
-			final boolean allowSyncMethods
-			) throws Exception {
+	public ModuleValidator(final String modulePath, final boolean verbose) throws Exception {
 		this.modulePath = modulePath;
 		this.verbose = verbose;
 		File module = new File(modulePath);
@@ -81,7 +76,6 @@ public class ModuleValidator {
 			);
 		}
 		this.methodStoreUrl = endPoint + "/narrative_method_store/rpc";
-		this.allowSyncMethods = allowSyncMethods;
 	}
 
     private static boolean isModuleDir(File dir) {
@@ -171,7 +165,7 @@ public class ModuleValidator {
 			        if (methodDir.isDirectory()) {
 			            System.out.println("\nValidating method in ("+methodDir+")");
 			            try {
-			                int status = validateMethodSpec(methodDir, parsedKidl, this.allowSyncMethods);
+			                int status = validateMethodSpec(methodDir, parsedKidl);
 			                if (status != 0) {
 			                    errors++; 
 			                    continue;
@@ -227,8 +221,7 @@ public class ModuleValidator {
     }
 	
 	
-	protected int validateMethodSpec(File methodDir, KbModule parsedKidl,
-	        boolean allowSyncMethods) throws IOException {
+	protected int validateMethodSpec(File methodDir, KbModule parsedKidl) throws IOException {
 	    NarrativeMethodStoreClient nms = new NarrativeMethodStoreClient(new URL(methodStoreUrl));
 	    nms.setAllSSLCertificatesTrusted(true);
 	    nms.setIsInsecureHttpConnectionAllowed(true);
@@ -251,7 +244,7 @@ public class ModuleValidator {
                         System.err.println("                (" + (num + 1) + ") " + warn);
                     }
                 }
-                validateMethodSpecMapping(spec, parsedKidl, allowSyncMethods);
+                validateMethodSpecMapping(spec, parsedKidl);
                 return 0;
             }
             System.err.println("  **ERROR** - method-spec validation failed:");
@@ -267,23 +260,17 @@ public class ModuleValidator {
         }
 	}
 
-	public static void validateMethodSpecMapping(String specText, KbModule parsedKidl,
-	        boolean allowSyncMethods) throws IOException {
-	    JsonNode spec = new ObjectMapper().readTree(specText);
+	public static void validateMethodSpecMapping(String specText, KbModule parsedKidl
+            ) throws IOException {
+        JsonNode spec = new ObjectMapper().readTree(specText);
         JsonNode behaviorNode = get("/", spec, "behavior");
-        if (behaviorNode.get("none") != null)
+        if (behaviorNode.get("none") != null) {
             return;  // Don't pay attention at viewer methods (since they don't use back-end)
-        if (!allowSyncMethods) {
-            String jobId = get("/", spec, "job_id_output_field").asText();
-            if (!jobId.equals("docker")) {
-                throw new IllegalStateException("  **ERROR** - can't find \"docker\" value within path " +
-                        "[job_id_output_field] in spec.json");
-            }
-        } else if (spec.get("job_id_output_field") == null ||
-                !spec.get("job_id_output_field").asText().equals("docker")) {
-            System.err.println("  **WARNINGS** - method is declared as synchronous and " +
-                    "will be skipped");
-            return;
+        }
+        final String jobId = get("/", spec, "job_id_output_field").asText();
+        if (!jobId.equals("docker")) { // tested manually
+            throw new IllegalStateException("  **ERROR** - can't find \"docker\" value within path " +
+                    "[job_id_output_field] in spec.json");
         }
         JsonNode parametersNode = get("/", spec, "parameters");
         Map<String, JsonNode> inputParamIdToType = new TreeMap<String, JsonNode>();

--- a/src/test/java/us/kbase/test/sdk/tester/ModuleTesterTest.java
+++ b/src/test/java/us/kbase/test/sdk/tester/ModuleTesterTest.java
@@ -88,7 +88,7 @@ public class ModuleTesterTest {
 				"auth_service_url_allow_insecure=" + 
 				TestConfigHelper.getAuthServiceUrlInsecure() + "\n";
 		FileUtils.writeStringToFile(testCfgFile, testCfgText);
-		int exitCode = new ModuleTester(moduleDir).runTests(skipValidation, false);
+		int exitCode = new ModuleTester(moduleDir).runTests(skipValidation);
 		System.out.println("Exit code: " + exitCode);
 		return exitCode;
 	}

--- a/src/test/java/us/kbase/test/sdk/validator/ModuleValidatorTest.java
+++ b/src/test/java/us/kbase/test/sdk/validator/ModuleValidatorTest.java
@@ -29,7 +29,7 @@ public class ModuleValidatorTest {
                 new StringReader(kidlSpec), null, null));
         KbModule parsedKidl = services.get(0).getModules().get(0);
         String methodSpec = loadTextResource("spec_" + num + ".properties");
-        ModuleValidator.validateMethodSpecMapping(methodSpec, parsedKidl, false);
+        ModuleValidator.validateMethodSpecMapping(methodSpec, parsedKidl);
     }
     
     private static String loadTextResource(String name) throws Exception {


### PR DESCRIPTION
* `--method_store`:
    * Misleading - is only used when the url can't be extracted from the test.cfg file, which should never happen unless the module is corrupt
    * As per above, should never happen under normal circumstances. The fix is to correct the test.cfg file.
* `--allow_async_method` is no longer relevant, all sdk methods are docker methods