### PR TITLE
Remove manual sha256 from binary release

### DIFF
--- a/.github/workflows/native_binary_release.yml
+++ b/.github/workflows/native_binary_release.yml
@@ -41,18 +41,10 @@ jobs:
         run: |
           mkdir -p release/
           cp build/native/nativeCompile/kb-sdk release/kb-sdk-${{ matrix.label }}
-          if command -v sha256sum >/dev/null 2>&1; then
-              # linux
-              sha256sum release/kb-sdk-${{ matrix.label }} > release/kb-sdk-${{ matrix.label }}.sha256
-          else
-              # mac
-              shasum -a 256 release/kb-sdk-${{ matrix.label }} > release/kb-sdk-${{ matrix.label }}.sha256
-          fi
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
           files: |
             release/kb-sdk-${{ matrix.label }}
-            release/kb-sdk-${{ matrix.label }}.sha256
           fail_on_unmatched_files: true


### PR DESCRIPTION
Github provides a sha256 in the release ui