### PR TITLE
Isolate SDK generated code test deps from SDK test deps proper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'application'
 	id 'jacoco'
 	id 'org.ajoberstar.grgit' version '4.1.1'
-	id 'org.graalvm.buildtools.native' version "0.10.6"
+	id 'org.graalvm.buildtools.native' version '0.10.6'
 }
 
 // TODO BUILD look into GraalVM native compilation vs. dockerizing kb-sdk
@@ -22,11 +22,11 @@ group = 'us.kbase.sdk'
 repositories {
 	mavenCentral()
 	maven {  // for syslog4j
-		name = "Clojars"
-		url = "https://repo.clojars.org/"
+		name = 'Clojars'
+		url = 'https://repo.clojars.org/'
 	}
 	maven {
-		name = "Jitpack"
+		name = 'Jitpack'
 		url = 'https://jitpack.io'
 	}
 }
@@ -66,7 +66,7 @@ task kb_sdk_plusScript {
 		}
 	
 		def buildjar = "$buildDir/libs/${project.name}.jar"
-		def classpath = buildjar + ":" + dependencies.join(':')
+		def classpath = buildjar + ':' + dependencies.join(':')
 	
 		def scriptContent = """#!/bin/sh
 
@@ -86,7 +86,7 @@ task prepareRunnableDir {
 	// Note requires bash vs just sh
 	dependsOn jar
 	def runnableDir = file("$buildDir/runnable")
-	def runnerScript = new File(runnableDir, "kb-sdk")
+	def runnerScript = new File(runnableDir, 'kb-sdk')
 
 	doFirst {
 		// Clean and recreate runnable dir
@@ -135,11 +135,24 @@ task pythonTest(type: Exec) {
 	}
 }
 
+// this is used in TypeGeneratorTest to supply dependencies for compiler tests
+def genCodeLibDir = file("$buildDir/generated-code-libs")
+
+task resolveGeneratedCodeDeps {
+	outputs.dir genCodeLibDir
+	doLast {
+		copy {
+			from configurations.generatedCodeClasspath
+			into genCodeLibDir
+		}
+	}
+}
+
 test {
+	dependsOn resolveGeneratedCodeDeps
 	dependsOn kb_sdk_plusScript  // tests use script to compile sdk modules
 	dependsOn pythonTest
 	
-	maxHeapSize = "3G"
 	testLogging {
 		exceptionFormat = 'full'
 		showStandardStreams = true
@@ -158,10 +171,10 @@ jacocoTestReport {
 		classDirectories.setFrom(
 			files(classDirectories.files.collect {
 				fileTree(dir: it, exclude: [
-					"**/common/executionengine/**",
-					"**/common/service/**",
-					"**/catalog/**",
-					"**/narrativemethodstore/**",
+					'**/common/executionengine/**',
+					'**/common/service/**',
+					'**/catalog/**',
+					'**/narrativemethodstore/**',
 				])
 			})
 		)
@@ -171,10 +184,12 @@ jacocoTestReport {
 // TODO BUILD the other script tasks could possibly be made simpler with some of the 
 //            variables in this task
 tasks.register('generateNativeAgentScript') {
-	description = "Generates a script to run the application with GraalVM native-image-agent. " +
-		"Will init and test an SDK app called 'testapp', so run this in a location where " +
-		"creating that directory is safe."
-	group = "native-image"
+	description = """
+		Generates a script to run the application with the GraalVM native-image-agent.
+		Will init and test an SDK app called 'testapp', so run this in a location where
+		creating that directory is safe.
+	"""
+	group = 'native-image'
 	
 	dependsOn jar
 
@@ -257,13 +272,13 @@ echo "Edit manually if necessary."
 
 graalvmNative {
 	binaries {
-		named("main") {
-			imageName.set("kb-sdk")
+		named('main') {
+			imageName.set('kb-sdk')
 			// Don't fall back to a jar based build
 			buildArgs.addAll([
-				"--no-fallback",
-				"--enable-url-protocols=https,http",
-				"-H:+AddAllCharsets"
+				'--no-fallback',
+				'--enable-url-protocols=https,http',
+				'-H:+AddAllCharsets'
 			])
 		}
 	}
@@ -272,6 +287,8 @@ graalvmNative {
 configurations {
 	// can't directly access testImplementation, so extend and access
 	testimpl.extendsFrom testImplementation
+	// isolate the sdk generated code dependencies from the standard dependencies
+	generatedCodeClasspath
 }
 
 configurations.all {
@@ -288,10 +305,10 @@ dependencies {
 	annotationProcessor 'info.picocli:picocli-codegen:4.7.7'
 	compileOnly 'javax.servlet:servlet-api:2.5'
 
-	implementation("com.github.kbase:auth2_client_java:0.5.0") {
+	implementation('com.github.kbase:auth2_client_java:0.5.0') {
 		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 	}
-	implementation("com.github.kbase:java_common:0.3.1") {
+	implementation('com.github.kbase:java_common:0.3.1') {
 		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 		exclude group: 'net.java.dev.jna' // don't include in runtime path
 	}
@@ -302,8 +319,8 @@ dependencies {
 		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 		exclude group: 'net.java.dev.jna' // don't include in runtime path
 	}
-	implementation "com.fasterxml.jackson.core:jackson-annotations:2.2.3"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.2.3"
+	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.2.3'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.2.3'
 	implementation 'com.google.guava:guava:18.0'
 	implementation 'com.googlecode.jsonschema2pojo:jsonschema2pojo-core:0.3.6'
 	implementation('com.j2html:j2html:0.7') {
@@ -334,7 +351,7 @@ dependencies {
 	// abandonware and has a ton of CVEs, even in the newer versions.
 	// Note that the java SDK modules use syslog4j, so we'll need to figure something out
 	// there. I doubt any of the apps actually use the logging code that triggers it though
-	implementation "org.syslog4j:syslog4j:0.9.46"
+	implementation 'org.syslog4j:syslog4j:0.9.46'
 
 	// needed for syslog4j. Used in java test modules and JsonServerServlet subclasses in tests
 	// but not in SDK code proper.
@@ -345,6 +362,29 @@ dependencies {
 	}
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'org.hamcrest:hamcrest-core:1.3'
+	
+	// isolate the sdk generated code dependencies from the standard dependencies
+	
+	generatedCodeClasspath 'ch.qos.logback:logback-classic:1.1.2'
+	generatedCodeClasspath 'com.fasterxml.jackson.core:jackson-annotations:2.2.3'
+	generatedCodeClasspath 'com.fasterxml.jackson.core:jackson-databind:2.2.3'
+	generatedCodeClasspath('com.github.kbase:auth2_client_java:0.5.0') {
+		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
+	}
+	generatedCodeClasspath('com.github.kbase:java_common:0.3.1') {
+		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
+		exclude group: 'net.java.dev.jna' // don't include in test path
+	}
+	generatedCodeClasspath 'javax.annotation:javax.annotation-api:1.3.2'
+	generatedCodeClasspath 'javax.servlet:servlet-api:2.5'
+	generatedCodeClasspath 'joda-time:joda-time:2.2'
+	generatedCodeClasspath 'junit:junit:4.12'
+	generatedCodeClasspath 'net.java.dev.jna:jna:3.4.0'
+	generatedCodeClasspath 'org.eclipse.jetty.aggregate:jetty-all:7.0.0.v20091005'
+	generatedCodeClasspath 'org.hamcrest:hamcrest-core:1.3'
+	generatedCodeClasspath 'org.ini4j:ini4j:0.5.2'
+	generatedCodeClasspath 'org.syslog4j:syslog4j:0.9.46'
+	generatedCodeClasspath 'org.slf4j:slf4j-api:1.7.7'
 }
 
 task showTestClassPath {


### PR DESCRIPTION
Allows updating the SDK code dependencies without breaking TypeGeneratorTest tests.