### PR TITLE
Add and use a TestLocalManager class

### DIFF
--- a/src/main/java/us/kbase/sdk/common/TestLocalManager.java
+++ b/src/main/java/us/kbase/sdk/common/TestLocalManager.java
@@ -1,0 +1,207 @@
+package us.kbase.sdk.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import us.kbase.sdk.templates.TemplateFormatter;
+
+/** Manages creation and restoration of the test_local folder in a SDK repo. */
+public class TestLocalManager {
+	
+	private static final Path TEST_LOCAL = Paths.get("test_local");
+	private static final String README = "readme.txt";
+	private static final String TEST_CFG = "test.cfg";
+	private static final String RUN_TESTS_SH = "run_tests.sh";
+	private static final String RUN_BASH_SH = "run_bash.sh";
+	private static final String RUN_DOCKER_SH = "run_docker.sh";
+	
+	/** Get the path of the test local directory relative to the module root.
+	 * @return the path.
+	 */
+	public static Path getTestLocalRelative() {
+		return TEST_LOCAL;
+	}
+	
+	/** Get the path of the test local readme file relative to the module root.
+	 * @return the path.
+	 */
+	public static Path getReadmeRelative() {
+		return TEST_LOCAL.resolve(README);
+	}
+	
+	/** Get the path of the test local run tests shell file relative to the module root.
+	 * @return the path.
+	 */
+	public static Path getRunTestsRelative() {
+		return TEST_LOCAL.resolve(RUN_TESTS_SH);
+	}
+	
+	/** Get the path of the test local run bash shell file relative to the module root.
+	 * @return the path.
+	 */
+	public static Path getRunBashRelative() {
+		return TEST_LOCAL.resolve(RUN_BASH_SH);
+	}
+	
+	/** Get the path of the test local run docker shell file relative to the module root.
+	 * @return the path.
+	 */
+	public static Path getRunDockerRelative() {
+		return TEST_LOCAL.resolve(RUN_DOCKER_SH);
+	}
+	
+	/** Get the path of the test config file relative to the module root.
+	 * @return the path.
+	 */
+	public static Path getTesCfgRelative() {
+		return TEST_LOCAL.resolve(TEST_CFG);
+	}
+	
+	/** The results of ensuring the test local directory. */
+	public static class TestLocalInfo {
+		private final Path testLocalDir;
+		private final boolean createdTestCfgFile;
+		
+		private TestLocalInfo(final Path testLocalDir, final boolean createdTestCfgFile) {
+			this.testLocalDir = testLocalDir;
+			this.createdTestCfgFile = createdTestCfgFile;
+		}
+
+		/** Get the path to the test local directory.
+		 * @return the path.
+		 */
+		public Path getTestLocalDir() {
+			return testLocalDir;
+		}
+
+		/** Get the path to the test local readme file.
+		 * @return the path.
+		 */
+		public Path getReadmeFile() {
+			return testLocalDir.resolve(README);
+		}
+
+		/** Get the path to the test local run tests shell file..
+		 * @return the path.
+		 */
+		public Path getRunTestsShFile() {
+			return testLocalDir.resolve(RUN_TESTS_SH);
+		}
+
+		/** Get the path to the test local run bash shell file.
+		 * @return the path.
+		 */
+		public Path getRunBashShFile() {
+			return testLocalDir.resolve(RUN_BASH_SH);
+		}
+
+		/** Get the path to the test local run docker shell file.
+		 * @return the path.
+		 */
+		public Path getRunDockerShFile() {
+			return testLocalDir.resolve(RUN_DOCKER_SH);
+		}
+
+		/** Get the path to the test local test config file.
+		 * @return the path.
+		 */
+		public Path getTestCfgFile() {
+			return testLocalDir.resolve(TEST_CFG);
+		}
+
+		/** Get whether the test config file was created as part of ensuring the test local
+		 * directory.
+		 * @return true if the test configuration file needed to be created. This means the user
+		 * will need to edit the file to add their credentials. 
+		 */
+		public boolean isCreatedTestCfgFile() {
+			return createdTestCfgFile;
+		}
+
+	}
+	
+	/** Create and / or restore the test local directory for an SDK app.
+	 * 
+	 * Will only overwrite files if they don't already exist.
+	 * 
+	 * @param moduleDir the SDK module root directory.
+	 * @param moduleName the name of the module.
+	 * @param dataVersion the version of the module's reference data, if applicable.
+	 * If provided, the "refdata" subfolder will be created if it doesn't exist. If is doesn't
+	 * exist, the test runner shell script will be regenerated to ensure it handles reference
+	 * data correctly.
+	 * @return information about the test local directory.
+	 * @throws IOException if a file or directory cannot be created.
+	 */
+	public static TestLocalInfo ensureTestLocal(
+			final Path moduleDir,
+			final String moduleName,
+			final Optional<String> dataVersion)
+			throws IOException {
+		final Path tlDir = requireNonNull(moduleDir, "moduleDir").resolve(TEST_LOCAL)
+				.toAbsolutePath();
+		final Path readmeFile = tlDir.resolve(README);
+		final Path testCfg = tlDir.resolve(TEST_CFG);
+		final Path runTestsSh = tlDir.resolve(RUN_TESTS_SH);
+		final Path runBashSh = tlDir.resolve(RUN_BASH_SH);
+		final Path runDockerSh = tlDir.resolve(RUN_DOCKER_SH);
+		final Map<String, Object> moduleContext = new HashMap<>();
+		// TODO CODE add a string checker that throws on whitespace only strings
+		moduleContext.put("module_name", requireNonNull(moduleName, "moduleName"));
+		Files.createDirectories(tlDir);
+		if (requireNonNull(dataVersion, "dataVersion").isPresent()) {
+			// TODO CODE add a string checker that throws on whitespace only strings
+			moduleContext.put("data_version", dataVersion.get());
+			final Path refDataDir = tlDir.resolve("refdata");
+			if (!Files.exists(refDataDir)) {
+				// We'll assume here that some bunghole hasn't created a file in the dir's place
+				// The missing refdata dir is treated as a signal that the user has added a
+				// refdata version to their kbase.yml file. That means the test runner
+				// needs to be regenerated to handle refdata.
+				// This all seems very clunky and could use a rethink
+				TemplateFormatter.formatTemplate(
+						"module_run_tests", moduleContext, runTestsSh.toFile()
+				);
+				Files.createDirectories(refDataDir);
+			}
+		}
+		boolean createdTestCfg = false;
+		// could make a template -> Path map here and DRY things up for all the but the last
+		// if. Meh
+		if (!Files.exists(readmeFile)) {
+			TemplateFormatter.formatTemplate(
+					"module_readme_test_local", moduleContext, readmeFile.toFile()
+			);
+		}
+		if (!Files.exists(runTestsSh)) {
+			TemplateFormatter.formatTemplate(
+					"module_run_tests", moduleContext, runTestsSh.toFile()
+			);
+		}
+		if (!Files.exists(runBashSh)) {
+			TemplateFormatter.formatTemplate(
+					"module_run_bash", moduleContext, runBashSh.toFile()
+			);
+		}
+		if (!Files.exists(runDockerSh)) {
+			TemplateFormatter.formatTemplate(
+					"module_run_docker", moduleContext, runDockerSh.toFile()
+			);
+		}
+		if (!Files.exists(testCfg)) {
+			TemplateFormatter.formatTemplate(
+					"module_test_cfg", moduleContext, testCfg.toFile()
+			);
+			createdTestCfg = true;
+		}
+		return new TestLocalInfo(tlDir, createdTestCfg);
+	}
+
+}

--- a/src/main/java/us/kbase/sdk/initializer/ModuleInitializer.java
+++ b/src/main/java/us/kbase/sdk/initializer/ModuleInitializer.java
@@ -9,9 +9,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import us.kbase.sdk.Language;
 import us.kbase.sdk.common.KBaseYmlConfig;
+import us.kbase.sdk.common.TestLocalManager;
 import us.kbase.sdk.compiler.JavaData;
 import us.kbase.sdk.compiler.JavaModule;
 import us.kbase.sdk.compiler.JavaTypeGenerator;
@@ -107,16 +109,15 @@ public class ModuleInitializer {
 		 * Set up the context - the set of variables used to flesh out the templates */
 		String specFile = Paths.get(this.moduleName + ".spec").toString();
 		
-		Map<String, Object> moduleContext = new HashMap<String, Object>();
+		Map<String, Object> moduleContext = new HashMap<>();
 		moduleContext.put("module_name", this.moduleName);
 		moduleContext.put("user_name", this.userName);
 		moduleContext.put("spec_file", specFile);
 		moduleContext.put("language", this.language);
 		moduleContext.put("module_root_path", Paths.get(moduleDir).toAbsolutePath());
+		moduleContext.put("test_cfg_loc", TestLocalManager.getTesCfgRelative());
 		moduleContext.put("example", example);
 		moduleContext.put("dollar_sign", "$");
-        moduleContext.put("os_name", System.getProperty("os.name"));
-
 
 		Map<String, Path> templateFiles = new HashMap<String, Path>();
 		templateFiles.put("module_typespec", Paths.get(moduleDir, specFile));
@@ -137,11 +138,6 @@ public class ModuleInitializer {
 		templateFiles.put("module_config_yaml", Paths.get(moduleDir, KBaseYmlConfig.KBASE_YAML));
         templateFiles.put("module_gitignore", Paths.get(moduleDir, ".gitignore"));
         templateFiles.put("module_dockerignore", Paths.get(moduleDir, ".dockerignore"));
-        templateFiles.put("module_readme_test_local", Paths.get(moduleDir, "test_local", "readme.txt"));
-        templateFiles.put("module_test_cfg", Paths.get(moduleDir, "test_local", "test.cfg"));
-        templateFiles.put("module_run_tests", Paths.get(moduleDir, "test_local", "run_tests.sh"));
-        templateFiles.put("module_run_bash", Paths.get(moduleDir, "test_local", "run_bash.sh"));
-        templateFiles.put("module_run_docker", Paths.get(moduleDir, "test_local", "run_docker.sh"));
 		
 		switch (language) {
 		case "java":
@@ -198,6 +194,8 @@ public class ModuleInitializer {
 			fillTemplate(moduleContext, templateName, templateFiles.get(templateName));
 		}
 		
+		TestLocalManager.ensureTestLocal(Paths.get(moduleDir), this.moduleName, Optional.empty());
+		
 		if (example) {
 			// Generated examples require some other SDK dependencies
             new ClientInstaller(new File(moduleDir), false).install(
@@ -240,7 +238,9 @@ public class ModuleInitializer {
 		System.out.println("Compile and run the example methods with the following inputs:");
 		System.out.println("  cd " + moduleDir);
 		System.out.println("  make          (required after making changes to " + new File(specFile).getName() + ")");
-		System.out.println("  kb-sdk test   (will require setting test user account credentials in test_local/test.cfg)");
+		System.out.println(String.format(
+				"  kb-sdk test   (will require setting test user account credentials in %s)",
+				TestLocalManager.getTesCfgRelative()));
 		System.out.println();
 	}
 	
@@ -273,7 +273,7 @@ public class ModuleInitializer {
 	 * @param outfile
 	 * @throws IOException
 	 */
-	private void fillTemplate(Map<?,?> context, String templateName, Path outfilePath) throws IOException {
+	private void fillTemplate(Map<String, Object> context, String templateName, Path outfilePath) throws IOException {
 		if (this.verbose) System.out.println("Building file \"" + outfilePath.toString() + "\"");
 		initDirectory(outfilePath.getParent(), false);
 		TemplateFormatter.formatTemplate(templateName, context, outfilePath.toFile());

--- a/src/main/java/us/kbase/sdk/runner/ModuleRunner.java
+++ b/src/main/java/us/kbase/sdk/runner/ModuleRunner.java
@@ -87,7 +87,7 @@ public class ModuleRunner {
         try (InputStream is = new FileInputStream(sdkCfgFile)) {
             sdkConfig.load(is);
         }
-        cfgLoader = new ConfigLoader(sdkConfig, false, sdkCfgPath, true);
+        cfgLoader = new ConfigLoader(sdkConfig, false, sdkCfgPath);
         catalogUrl = new URL(cfgLoader.getCatalogUrl());
         runDir = new File(sdkHomeDir, "run_local");
         String callbackNetworksText = sdkConfig.getProperty("callback_networks");

--- a/src/main/java/us/kbase/sdk/templates/TemplateFormatter.java
+++ b/src/main/java/us/kbase/sdk/templates/TemplateFormatter.java
@@ -18,7 +18,7 @@ import us.kbase.sdk.util.TextUtils;
 
 public class TemplateFormatter {
 
-    public static boolean formatTemplate(String templateName, Map<?,?> context, 
+    public static boolean formatTemplate(String templateName, Map<String, Object> context, 
             File output) throws IOException {
         StringWriter sw = new StringWriter();
         boolean ret = formatTemplate(templateName, context, sw);
@@ -29,7 +29,7 @@ public class TemplateFormatter {
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static boolean formatTemplate(String templateName, Map<?,?> context, 
+    public static boolean formatTemplate(String templateName, Map<String, Object> context, 
             Writer output) {
         try {
             if (!context.containsKey("esc")) {

--- a/src/main/java/us/kbase/sdk/tester/ConfigLoader.java
+++ b/src/main/java/us/kbase/sdk/tester/ConfigLoader.java
@@ -29,10 +29,10 @@ public class ConfigLoader {
     private final String catalogUrl;
     private final Map<String, String> secureCfgParams;
 
-    public ConfigLoader(Properties props, boolean testMode, 
-            String configPathInfo, boolean tryHomeCfg) throws Exception {
+    public ConfigLoader(Properties props, boolean testMode, String configPathInfo
+            ) throws Exception {
         if (configPathInfo == null) {
-            configPathInfo = "test_local/test.cfg";
+            throw new IllegalArgumentException("configPathInfo is required");
         }
         authUrl = props.getProperty("auth_service_url");
         if (authUrl == null)

--- a/src/main/java/us/kbase/sdk/tester/ModuleTester.java
+++ b/src/main/java/us/kbase/sdk/tester/ModuleTester.java
@@ -40,8 +40,9 @@ import us.kbase.common.service.JsonServerSyslog.SyslogOutput;
 import us.kbase.common.service.UObject;
 import us.kbase.common.utils.NetUtils;
 import us.kbase.sdk.common.KBaseYmlConfig;
+import us.kbase.sdk.common.TestLocalManager;
+import us.kbase.sdk.common.TestLocalManager.TestLocalInfo;
 import us.kbase.sdk.initializer.ModuleInitializer;
-import us.kbase.sdk.templates.TemplateFormatter;
 import us.kbase.sdk.util.DirUtils;
 import us.kbase.sdk.util.ProcessHelper;
 import us.kbase.sdk.util.TextUtils;
@@ -84,12 +85,19 @@ public class ModuleTester {
     
     public int runTests(final boolean skipValidation) throws Exception {
         // TODO CODE some of this code looks similar to that in the module runner, DRY possible
+        final TestLocalInfo tli = TestLocalManager.ensureTestLocal(
+                moduleDir.toPath(),
+                kbaseYmlConfig.getModuleName(),
+                kbaseYmlConfig.getDataVersion()
+        );
+        final String testLocalRel = TestLocalManager.getTestLocalRelative().toString();
+        final String testCfgRel = TestLocalManager.getTesCfgRelative().toString();
         if (skipValidation) {
             System.out.println("Validation step is skipped");
         } else {
             ModuleValidator mv = new ModuleValidator(moduleDir.getCanonicalPath(), false);
             int returnCode = mv.validate();
-            if (returnCode!=0) {
+            if (returnCode != 0) {
                 System.out.println("You can skip validation step using -s (or --skip_validation)" +
                 		" flag");
                 // TODO CODE should be throwing exceptions, not returning return codes all over the
@@ -97,40 +105,20 @@ public class ModuleTester {
                 return returnCode;
             }
         }
-        String testLocal = "test_local";
-        checkIgnoreLine(new File(moduleDir, ".gitignore"), testLocal);
-        checkIgnoreLine(new File(moduleDir, ".dockerignore"), testLocal);
-        File tlDir = new File(moduleDir, testLocal);
-        File readmeFile = new File(tlDir, "readme.txt");
-        File testCfg = new File(tlDir, "test.cfg");
-        File runTestsSh = new File(tlDir, "run_tests.sh");
-        File runBashSh = new File(tlDir, "run_bash.sh");
-        File runDockerSh = new File(tlDir, "run_docker.sh");
-        if (!tlDir.exists())
-            tlDir.mkdir();
-        if (!readmeFile.exists())
-            TemplateFormatter.formatTemplate("module_readme_test_local", moduleContext,
-                    readmeFile);
-        if (kbaseYmlConfig.getDataVersion().isPresent()) {
-            File refDataDir = new File(tlDir, "refdata");
-            if (!refDataDir.exists()) {
-                TemplateFormatter.formatTemplate("module_run_tests", moduleContext, 
-                        runTestsSh);
-                refDataDir.mkdir();
-            }
-        }
-        if (!runTestsSh.exists())
-            TemplateFormatter.formatTemplate("module_run_tests", moduleContext, runTestsSh);
-        if (!runBashSh.exists())
-            TemplateFormatter.formatTemplate("module_run_bash", moduleContext, runBashSh);
-        if (!runDockerSh.exists())
-            TemplateFormatter.formatTemplate("module_run_docker", moduleContext, runDockerSh);
-        if (!testCfg.exists()) {
-            TemplateFormatter.formatTemplate("module_test_cfg", moduleContext, testCfg);
-            System.out.println("Set KBase account credentials in test_local/test.cfg and then " +
-            		"test again");
+        checkIgnoreLine(new File(moduleDir, ".gitignore"), testLocalRel);
+        checkIgnoreLine(new File(moduleDir, ".dockerignore"), testLocalRel);
+        if (tli.isCreatedTestCfgFile()) {
+            System.out.println(String.format(
+                    "Set KBase account credentials in %s and then test again", testCfgRel
+            ));
             return 1;
         }
+        // TODO CODE update the code below to use Path
+        final File testCfg = tli.getTestCfgFile().toFile();
+        final File tlDir = tli.getTestLocalDir().toFile();
+        final File runDockerSh = tli.getRunDockerShFile().toFile();
+        final File runBashSh = tli.getRunBashShFile().toFile();
+        final File runTestsSh = tli.getRunTestsShFile().toFile();
         Properties props = new Properties();
         InputStream is = new FileInputStream(testCfg);
         try {
@@ -139,8 +127,7 @@ public class ModuleTester {
             is.close();
         }
         
-        ConfigLoader cfgLoader = new ConfigLoader(props, true, "test_local/test.cfg", true);
-        
+        final ConfigLoader cfgLoader = new ConfigLoader(props, true, testCfgRel);
         
         File workDir = new File(tlDir, "workdir");
         workDir.mkdir();

--- a/src/main/java/us/kbase/sdk/validator/ModuleValidator.java
+++ b/src/main/java/us/kbase/sdk/validator/ModuleValidator.java
@@ -37,41 +37,49 @@ import us.kbase.narrativemethodstore.NarrativeMethodStoreClient;
 import us.kbase.narrativemethodstore.ValidateMethodParams;
 import us.kbase.narrativemethodstore.ValidationResults;
 import us.kbase.sdk.common.KBaseYmlConfig;
+import us.kbase.sdk.common.TestLocalManager;
+import us.kbase.sdk.common.TestLocalManager.TestLocalInfo;
 
 
 public class ModuleValidator {
 	
-	protected String modulePath;
-	protected boolean verbose;
-	protected String methodStoreUrl;
+	private String modulePath;
+	private boolean verbose;
 
 	public ModuleValidator(final String modulePath, final boolean verbose) throws Exception {
 		this.modulePath = modulePath;
 		this.verbose = verbose;
-		File module = new File(modulePath);
-		// TODO CODE don't hardcode file names and directories everywhere
-		File testCfg = new File(new File(module, "test_local"), "test.cfg");
+	}
+
+	private String getMethodStoreUrl(final Path mod, final KBaseYmlConfig kyc) throws IOException {
+		// ensure test_local/test.cfg exists before trying to get a url from it
+		final TestLocalInfo tlm = TestLocalManager.ensureTestLocal(
+				mod,
+				kyc.getModuleName(),
+				kyc.getDataVersion()
+		);
+		final Path tltc = TestLocalManager.getTesCfgRelative();
 		// everything except the happy path is currently tested manually
-		if (!testCfg.exists()) {
-			// TODO CODE IllegalStateException is used for everything - maybe not terrible in
-			//           a CLI?
-			throw new IllegalStateException(
-					"test_local/test.cfg file is missing from SDK module"
-			);
-		}
 		final Properties props = new Properties();
-		try (final InputStream is = new FileInputStream(testCfg);) {
+		try (final InputStream is = new FileInputStream(tlm.getTestCfgFile().toFile());) {
 			props.load(is);
 		} catch (Exception e) {
-			throw new IOException("Could not read test_local/test.cfg file: " + e.getMessage(), e);
+			throw new IOException(String.format(
+					"Could not read %s file: " + e.getMessage(), tltc), e
+			);
 		}
 		final String endPoint = props.getProperty("kbase_endpoint");
 		if (endPoint == null) {
-			throw new IllegalStateException(
-					"test_local/test.cfg file is missing the kbase_endpoint property"
-			);
+			throw new IllegalStateException(String.format(
+					"%s file is missing the kbase_endpoint property", tltc
+			));
 		}
-		this.methodStoreUrl = endPoint + "/narrative_method_store/rpc";
+		final String msurl = endPoint + "/narrative_method_store/rpc";
+		
+		System.out.println(String.format(
+				"Using Narrative Method Store URL from %s for module validation:\n%s", tltc, msurl
+		));
+		return msurl;
 	}
 
     private static boolean isModuleDir(File dir) {
@@ -83,12 +91,13 @@ public class ModuleValidator {
                 new File(dir, "test").exists() &&
                 new File(dir, "ui").exists();
     }
-	
+
 	public int validate() {
-		
+
 		int errors = 0;
-		
+
 		// TODO CODE remove this crufty loop
+		// TODO CODE this whole module needs a rewrite
 		for(String modulePathString : Arrays.asList(modulePath)) {
 			File module = new File(modulePathString);
 			System.out.println("\nValidating module in ("+module+")");
@@ -116,13 +125,17 @@ public class ModuleValidator {
 				System.err.println("                "+e.getMessage());
 			}
 
-
 			// 1) Validate the configuration file
+			final KBaseYmlConfig kyc;
 			try {
-				int status = validateKBaseYmlConfig(module);
-				if(status!=0) {
-					errors++;
-					continue;
+				final Path kbaseYmlFile = module.toPath().toAbsolutePath()
+						.resolve(KBaseYmlConfig.KBASE_YAML);
+				if (verbose) {
+					System.out.println("  - configuration file = " + kbaseYmlFile);
+				}
+				kyc = new KBaseYmlConfig(module.toPath());
+				if (verbose) {
+					System.out.println("  - configuration file %s is valid YAML");
 				}
 			} catch (Exception e) {
 				System.err.println("  **ERROR** - configuration file validation failed:");
@@ -131,9 +144,19 @@ public class ModuleValidator {
 				continue;
 			}
 			
+			String methodStoreUrl = null;
+			try {
+				methodStoreUrl = getMethodStoreUrl(module.toPath(), kyc);
+			} catch (IOException | IllegalStateException e) {
+				System.err.println("  **ERROR** - getting Narrative Method Store URL failed:");
+				System.err.println("                "+e.getMessage());
+				errors++;
+				continue;
+			}
+
 			KbModule parsedKidl = null;
             try {
-                final String moduleName = new KBaseYmlConfig(module.toPath()).getModuleName();
+                final String moduleName = kyc.getModuleName();
                 File specFile = new File(module, moduleName + ".spec");
                 if (!specFile.exists())
                     throw new IllegalStateException("Spec-file isn't found: " + specFile);
@@ -160,7 +183,7 @@ public class ModuleValidator {
 			        if (methodDir.isDirectory()) {
 			            System.out.println("\nValidating method in ("+methodDir+")");
 			            try {
-			                int status = validateMethodSpec(methodDir, parsedKidl);
+			                int status = validateMethodSpec(methodDir, parsedKidl, methodStoreUrl);
 			                if (status != 0) {
 			                    errors++; 
 			                    continue;
@@ -183,25 +206,11 @@ public class ModuleValidator {
 		return 0;
 	}
 	
-	protected int validateKBaseYmlConfig(File module) throws IOException {
-		final Path kbaseYmlFile = module.toPath().resolve(KBaseYmlConfig.KBASE_YAML);
-		if (verbose) {
-			System.out.println("  - configuration file = " + kbaseYmlFile);
-		}
-		try {
-			new KBaseYmlConfig(module.toPath());
-			if (verbose) {
-				System.out.println("  - configuration file is valid YAML");
-			}
-		} catch(Exception e) {
-			System.err.println("  **ERROR** - " + e.getMessage());
-			return 1;
-			
-		}
-		return 0;
-	}
-
-	protected int validateMethodSpec(File methodDir, KbModule parsedKidl) throws IOException {
+	private int validateMethodSpec(
+			final File methodDir,
+			final KbModule parsedKidl,
+			final String methodStoreUrl
+			) throws IOException {
 	    NarrativeMethodStoreClient nms = new NarrativeMethodStoreClient(new URL(methodStoreUrl));
 	    nms.setAllSSLCertificatesTrusted(true);
 	    nms.setIsInsecureHttpConnectionAllowed(true);

--- a/src/main/resources/us/kbase/sdk/templates/module_readme.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_readme.vm.properties
@@ -8,7 +8,7 @@ You can also learn more about the apps implemented in this module from its [cata
 
 # Setup and test
 
-Add your KBase developer token to `test_local/test.cfg` and run the following:
+Add your KBase developer token to `$test_cfg_loc` and run the following:
 
 ```bash
 $ make

--- a/src/main/resources/us/kbase/sdk/templates/module_readme_test_local.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_readme_test_local.vm.properties
@@ -1,7 +1,7 @@
-This directory contains temporary scripts and files needed to run tests 
-locally in Docker installed on developers' machine. These files are not
-supposed to be commited into git repo or to be copied inside Docker
-image.
+This directory contains temporary scripts and files needed to run tests
+locally in Docker installed on developers' machines. These files are not
+supposed to be committed into version control or to be copied inside the
+Docker image.
 
 To run tests:
 - add a valid test_token to test.cfg file

--- a/src/main/resources/us/kbase/sdk/templates/module_release_notes.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_release_notes.vm.properties
@@ -1,6 +1,6 @@
 # $module_name release notes
 =========================================
 
-0.0.0
+0.1.0
 -----
 * Module created by kb-sdk init

--- a/src/main/resources/us/kbase/sdk/templates/module_run_bash.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_run_bash.vm.properties
@@ -1,14 +1,3 @@
 #!/bin/bash
-#set ($iswin = $os_name.toLowerCase().contains("win"))
-#if ($iswin)
-get_short_path() {
-    local td=$(cmd //c for %I in \( "`echo $1 | sed 's/\///'  | sed 's/^\(.\)/\1:/' | tr '/' '\\' 2>/dev/null`" \) do echo %~fsI | tail -n1);
-    local ty=$(echo "$td" | sed "s/://" | tr '\\' '/' 2>/dev/null);
-    echo "/$ty";
-}
-#end
 script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
-#if ($iswin)
-script_dir=$(get_short_path "$script_dir");
-#end
 $script_dir/run_docker.sh run -i -t -v $script_dir/workdir:/kb/module/work test/${module_name.toLowerCase()}:latest bash

--- a/src/main/resources/us/kbase/sdk/templates/module_run_tests.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_run_tests.vm.properties
@@ -1,16 +1,5 @@
 #!/bin/bash
-#set ($iswin = $os_name.toLowerCase().contains("win"))
-#if ($iswin)
-get_short_path() {
-    local td=$(cmd //c for %I in \( "`echo $1 | sed 's/\///'  | sed 's/^\(.\)/\1:/' | tr '/' '\\' 2>/dev/null`" \) do echo %~fsI | tail -n1);
-    local ty=$(echo "$td" | sed "s/://" | tr '\\' '/' 2>/dev/null);
-    echo "/$ty";
-}
-#end
 script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
-#if ($iswin)
-    script_dir=$(get_short_path "$script_dir");
-#end
 cd $script_dir/..
 #if ($data_version)
 if [ -f "$script_dir/refdata/__READY__" ]; then

--- a/src/test/java/us/kbase/test/sdk/common/TestLocalManagerTest.java
+++ b/src/test/java/us/kbase/test/sdk/common/TestLocalManagerTest.java
@@ -1,0 +1,327 @@
+package us.kbase.test.sdk.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.sdk.common.TestLocalManager;
+import us.kbase.sdk.common.TestLocalManager.TestLocalInfo;
+
+public class TestLocalManagerTest {
+	
+	private static final String README_FILE = "readme.txt";
+	private static final String TEST_CFG_FILE = "test.cfg";
+	private static final String RUN_DOCKER_FILE = "run_docker.sh";
+	private static final String RUN_BASH_FILE = "run_bash.sh";
+	private static final String RUN_TESTS_FILE = "run_tests.sh";
+	private static final List<String> ALL_FILES = Arrays.asList(
+			README_FILE, TEST_CFG_FILE, RUN_DOCKER_FILE, RUN_BASH_FILE, RUN_TESTS_FILE
+	);
+
+	private static final String README = """
+			This directory contains temporary scripts and files needed to run tests
+			locally in Docker installed on developers' machines. These files are not
+			supposed to be committed into version control or to be copied inside the
+			Docker image.
+			
+			To run tests:
+			- add a valid test_token to test.cfg file
+			- run "kb-sdk test"
+			""";
+	
+	private static final String TEST_CFG = """
+			# PLEASE DO NOT COMMIT THIS FILE INTO VERSION CONTROL!
+			# Add a test_token from  your KBase developer account.
+			# Tokens may be generated at https://narrative.kbase.us/account/dev-tokens.
+			# If you don't have access to the developer tokens tab, please contact us:
+			# https://www.kbase.us/support/
+			
+			test_token=
+			kbase_endpoint=https://appdev.kbase.us/services
+			
+			# Next set of URLs correspond to core services. By default they
+			# are defined automatically based on 'kbase_endpoint':
+			#job_service_url=
+			#workspace_url=
+			#shock_url=
+			#handle_url=
+			#srv_wiz_url=
+			#njsw_url=
+			#catalog_url=
+			
+			#auth2-service URL:
+			auth_service_url=https://appdev.kbase.us/services/auth/api/legacy/KBase/Sessions/Login
+			auth_service_url_allow_insecure=false
+			
+			#callback_networks=docker0,vboxnet0,vboxnet1,eth0,en0,en1,en2,en3
+			""";
+	
+	private static final String RUN_DOCKER = """
+			#!/bin/bash
+			docker $@
+			""";
+	
+	private static final String RUN_BASH = """
+			#!/bin/bash
+			script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+			$script_dir/run_docker.sh run -i -t -v $script_dir/workdir:/kb/module/work test/%s:latest bash
+			""";
+	
+	private static final String RUN_TESTS = """
+			#!/bin/bash
+			script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+			cd $script_dir/..
+			$script_dir/run_docker.sh run -v $script_dir/workdir:/kb/module/work -e "SDK_CALLBACK_URL=$1" test/%s:latest test
+			""";
+	
+	private static final String RUN_TESTS_WITH_REFDATA = """
+			#!/bin/bash
+			script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+			cd $script_dir/..
+			if [ -f "$script_dir/refdata/__READY__" ]; then
+			    echo "Reference data initialization is skipped because it was already prepared"
+			else
+			    echo "Reference data initialization"
+			    if [ -d "$script_dir/refdata" ]; then
+			        rm -r $script_dir/refdata/*
+			    else
+			        mkdir $script_dir/refdata
+			    fi
+			    $script_dir/run_docker.sh run -v $script_dir/workdir:/kb/module/work -v $script_dir/refdata:/data -v $script_dir/../data:/kb/module/data -e "SDK_CALLBACK_URL=$1" test/%s:latest init
+			fi
+			if [ -f "$script_dir/refdata/__READY__" ]; then
+			    $script_dir/run_docker.sh run -v $script_dir/workdir:/kb/module/work -v $script_dir/refdata:/data:ro -e "SDK_CALLBACK_URL=$1" test/%s:latest test
+			else
+			    echo "ERROR: __READY__ file is not detected. Reference data initialization wasn't done correctly."
+			    exit 1
+			fi
+			""";
+
+	@TempDir
+	private Path tempModuleDir;
+
+	private Path testLocalDir;
+	private Path refdataDir;
+
+	@BeforeEach
+	void setup() {
+		testLocalDir = tempModuleDir.resolve("test_local");
+		refdataDir = testLocalDir.resolve("refdata");
+	}
+	
+	@Test
+	void testStaticMethods() {
+		assertThat(TestLocalManager.getReadmeRelative(), is(Paths.get("test_local/readme.txt")));
+		assertThat(TestLocalManager.getRunBashRelative(), is(Paths.get("test_local/run_bash.sh")));
+		assertThat(TestLocalManager.getRunDockerRelative(),
+				is(Paths.get("test_local/run_docker.sh"))
+		);
+		assertThat(TestLocalManager.getRunTestsRelative(),
+				is(Paths.get("test_local/run_tests.sh"))
+		);
+		assertThat(TestLocalManager.getTesCfgRelative(), is(Paths.get("test_local/test.cfg")));
+		assertThat(TestLocalManager.getTestLocalRelative(), is(Paths.get("test_local")));
+	}
+	
+	@Test
+	void testCreateAllFilesThenOverwriteDataVersion() throws Exception {
+		TestLocalInfo tlm = TestLocalManager.ensureTestLocal(
+				tempModuleDir, "foobar", Optional.empty()
+		);
+		assertOnStandardFileContents("foobar", false);
+		assertThat("refdata directory should not exist", Files.exists(refdataDir), is(false));
+		assertTLMCorrect(tlm, true);
+		
+		tlm = TestLocalManager.ensureTestLocal(
+				tempModuleDir, "foobar", Optional.of("0.1")
+		);
+		assertOnStandardFileContents("foobar", true);
+		assertThat("refdata directory should exist", Files.exists(refdataDir), is(true));
+		assertTLMCorrect(tlm, false);
+	}
+	
+	@Test
+	void testNoopThenOverwriteWithDataVersion() throws Exception {
+		// test the case where test_local is all set up
+		Files.createDirectories(testLocalDir);
+		for (final String file: ALL_FILES) {
+			Files.writeString(testLocalDir.resolve(file), "don't overwrite");
+		}
+		TestLocalInfo tlm = TestLocalManager.ensureTestLocal(
+				tempModuleDir, "mymod", Optional.empty()
+		);
+		for (final String file: ALL_FILES) {
+			final String contents = Files.readString(testLocalDir.resolve(file));
+			assertThat(String.format("File contents incorrect for %s", file),
+					contents, is("don't overwrite"));
+		}
+		assertThat("refdata directory should not exist", Files.exists(refdataDir), is(false));
+		assertTLMCorrect(tlm, false);
+		
+		// now test overwrite for just run tests
+		tlm = TestLocalManager.ensureTestLocal(
+				tempModuleDir, "mymod", Optional.of("0.1")
+		);
+		final List<String> sub = new ArrayList<>(ALL_FILES);
+		sub.remove(RUN_TESTS_FILE);
+		for (final String file: sub) {
+			final String contents = Files.readString(testLocalDir.resolve(file));
+			assertThat(String.format("File contents incorrect for %s", file),
+					contents, is("don't overwrite"));
+		}
+		final String contents = Files.readString(testLocalDir.resolve(RUN_TESTS_FILE));
+		assertThat("incorrect run test contents",
+				contents, is(String.format(RUN_TESTS_WITH_REFDATA, "mymod", "mymod"))
+		);
+		assertThat("refdata directory should exist", Files.exists(refdataDir), is(true));
+		assertTLMCorrect(tlm, false);
+	}
+	
+	@Test
+	public void testNoOverwriteWhenRefdataExists() throws Exception {
+		Files.createDirectories(refdataDir);
+		for (final String file: ALL_FILES) {
+			Files.writeString(testLocalDir.resolve(file), "don't overwrite");
+		}
+		TestLocalInfo tlm = TestLocalManager.ensureTestLocal(
+				tempModuleDir, "mymod", Optional.of("0.3")
+		);
+		for (final String file: ALL_FILES) {
+			final String contents = Files.readString(testLocalDir.resolve(file));
+			assertThat(String.format("File contents incorrect for %s", file),
+					contents, is("don't overwrite"));
+		}
+		assertThat("refdata directory should exist", Files.exists(refdataDir), is(true));
+		assertTLMCorrect(tlm, false);
+	}
+	
+	@Test
+	public void testRestoreReadme() throws Exception {
+		testRestoreFile(README_FILE, README, false);
+	}
+	
+	@Test
+	public void testTestCfg() throws Exception {
+		testRestoreFile(TEST_CFG_FILE, TEST_CFG, true);
+	}
+	
+	@Test
+	public void testRestoreRunDocker() throws Exception {
+		testRestoreFile(RUN_DOCKER_FILE, RUN_DOCKER, false);
+	}
+	
+	@Test
+	public void testRestoreRunBash() throws Exception {
+		testRestoreFile(RUN_BASH_FILE, String.format(RUN_BASH, "neatmod"), false);
+	}
+	
+	@Test
+	public void testRestoreRunTests() throws Exception {
+		testRestoreFile(RUN_TESTS_FILE, String.format(RUN_TESTS, "neatmod"), false);
+	}
+
+	private void testRestoreFile(
+			final String filename,
+			final String contents,
+			final boolean createdTestConfig
+			) throws Exception {
+		Files.createDirectories(testLocalDir);
+		final List<String> sub = new ArrayList<>(ALL_FILES);
+		sub.remove(filename);
+		for (final String file: sub) {
+			Files.writeString(testLocalDir.resolve(file), "don't overwrite");
+		}
+		TestLocalInfo tlm = TestLocalManager.ensureTestLocal(
+				tempModuleDir, "neatmod", Optional.empty()
+		);
+		for (final String file: sub) {
+			final String con = Files.readString(testLocalDir.resolve(file));
+			assertThat(String.format("File contents incorrect for %s", file),
+					con, is("don't overwrite"));
+		}
+		final String gotcon = Files.readString(testLocalDir.resolve(filename));
+		assertThat("incorrect file contents", gotcon, is(contents)
+		);
+		assertThat("refdata directory should not exist", Files.exists(refdataDir), is(false));
+		assertTLMCorrect(tlm, createdTestConfig);
+		
+	}
+	
+	private void assertTLMCorrect(final TestLocalInfo tlm, final boolean createdTestCfg) {
+		assertThat("incorrect created test cfg", tlm.isCreatedTestCfgFile(), is(createdTestCfg));
+		assertThat("incorrect test_local path", tlm.getTestLocalDir(), is(testLocalDir));
+		assertThat("incorrect readme path",
+				tlm.getReadmeFile(), is(testLocalDir.resolve(README_FILE))
+		);
+		assertThat("incorrect test.cfg path",
+				tlm.getTestCfgFile(), is(testLocalDir.resolve(TEST_CFG_FILE))
+		);
+		assertThat("incorrect run docker path",
+				tlm.getRunDockerShFile(), is(testLocalDir.resolve(RUN_DOCKER_FILE))
+		);
+		assertThat("incorrect run bash path",
+				tlm.getRunBashShFile(), is(testLocalDir.resolve(RUN_BASH_FILE))
+		);
+		assertThat("incorrect run tests path",
+				tlm.getRunTestsShFile(), is(testLocalDir.resolve(RUN_TESTS_FILE))
+		);
+	}
+
+	private void assertOnStandardFileContents(final String module, final boolean refdata
+			) throws IOException {
+		final String rt = refdata ? RUN_TESTS_WITH_REFDATA : RUN_TESTS;
+		final Map<String, String> testcases = ImmutableMap.of(
+				README_FILE, README,
+				TEST_CFG_FILE, TEST_CFG,
+				RUN_DOCKER_FILE, RUN_DOCKER,
+				RUN_BASH_FILE, String.format(RUN_BASH, module),
+				RUN_TESTS_FILE, String.format(rt, module, module)
+		);
+		for (final String file: testcases.keySet()) {
+			final String contents = Files.readString(testLocalDir.resolve(file));
+			assertThat(String.format("File contents incorrect for %s", file),
+					contents, is(testcases.get(file)));
+		}
+	}
+	
+	
+	@Test
+	public void testBadArguments() throws Exception {
+		Exception e = assertThrows(
+				NullPointerException.class,
+				() -> TestLocalManager.ensureTestLocal(null, "foo", Optional.empty())
+		);
+		assertThat("Incorrect exception", e.getMessage(), is("moduleDir"));
+		
+		// TODO TEST check for whitespace only strings when that's fixed
+		e = assertThrows(
+				NullPointerException.class,
+				() -> TestLocalManager.ensureTestLocal(Paths.get("a"), null, Optional.empty())
+		);
+		assertThat("Incorrect exception", e.getMessage(), is("moduleName"));
+		
+		// TODO TEST check for whitespace only strings in the optional when that's fixed
+		e = assertThrows(
+				NullPointerException.class,
+				() -> TestLocalManager.ensureTestLocal(Paths.get("a"), "a", null)
+		);
+		assertThat("Incorrect exception", e.getMessage(), is("dataVersion"));
+	}
+
+}


### PR DESCRIPTION
Ensures test_local is set up correctly when init, test, or validate is run, and that an appropriate error message is provided for test if test credentials are missing.

Fixes a regression that caused the test_local directory to not be regenerated if it's missing on kb-sdk test; would return an unhelpful message that the directory wasn't set up correctly.

Fixes #129 