### PR TITLE
Add a provenance class for the Callback server.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,6 +335,7 @@ dependencies {
 	implementation('org.ini4j:ini4j:0.5.2')
 	implementation('com.sun.codemodel:codemodel:2.4.1')
 	implementation('org.yaml:snakeyaml:1.11')
+	implementation('com.github.zafarkhaja:java-semver:0.10.2')
 
 	// TODO DEPS the deps below are required due to a) the callback server code, b)
 	//           tests that mock service wizard and the callback service and
@@ -355,16 +356,16 @@ dependencies {
 	// there. I doubt any of the apps actually use the logging code that triggers it though
 	implementation('org.syslog4j:syslog4j:0.9.46')
 
-	// needed for syslog4j. Used in java test modules and JsonServerServlet subclasses in tests
-	// but not in SDK code proper.
-	testImplementation('net.java.dev.jna:jna:3.4.0')
-	
 	testImplementation ('com.github.kbase:java_test_utilities:0.1.0') {
 		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 		exclude group: 'junit', module: 'junit'
 	}
-	testImplementation('org.junit.jupiter:junit-jupiter:5.13.1')
+	// needed for syslog4j. Used in java test modules and JsonServerServlet subclasses in tests
+	// but not in SDK code proper.
+	testImplementation('net.java.dev.jna:jna:3.4.0')
+	testImplementation("nl.jqno.equalsverifier:equalsverifier:4.0.7")
 	testImplementation('org.hamcrest:hamcrest:3.0')
+	testImplementation('org.junit.jupiter:junit-jupiter:5.13.1')
 	
 	// isolate the sdk generated code dependencies from the standard dependencies
 	

--- a/src/main/java/us/kbase/sdk/callback/CallbackProvenance.java
+++ b/src/main/java/us/kbase/sdk/callback/CallbackProvenance.java
@@ -1,0 +1,209 @@
+package us.kbase.sdk.callback;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.zafarkhaja.semver.Version;
+
+/**
+ * Immutable value class representing initial provenance information for a callback service.
+ * Instances are created via {@link #getBuilder(String, Version)}.
+ */
+public final class CallbackProvenance {
+
+	private static final Pattern MODULE_METHOD_PATTERN =
+		Pattern.compile("^[A-Za-z0-9_]+\\.[A-Za-z0-9_]+$");
+
+	private static final Pattern SERVICE_VER_PATTERN =
+		Pattern.compile("^(release|beta|dev|[0-9a-f]{7,40})$");
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private final String modulemethod;
+	private final Version version;
+	private final String serviceVer;
+	private final List<Object> params;
+	private final List<String> workspaceRefs;
+
+	private CallbackProvenance(Builder b) {
+		this.modulemethod = b.modulemethod;
+		this.version = b.version;
+		this.serviceVer = b.serviceVer;
+		this.params = Collections.unmodifiableList(b.params);
+		this.workspaceRefs = Collections.unmodifiableList(b.workspaceRefs);
+	}
+
+	/**
+	 * Get the method to be stored in initial callback server provenance as the method run
+	 * in "module.method" format.
+	 *  @return the SDK method to store in initial callback server provenance.
+	 */
+	public String getModuleMethod() {
+		return modulemethod;
+	}
+
+	/**
+	 * Get the version of the module to be stored in provenance.
+	 *  @return the module version.
+	 */
+	public Version getVersion() {
+		return version;
+	}
+
+	/**
+	 * Get the service version of the module to be stored in initial callback server provenance
+	 * either "relase", "beta', "dev", or a git hash.
+	 * @return the service version
+	 */
+	public String getServiceVer() {
+		return serviceVer;
+	}
+
+	/**
+	 * Get the parameters of the method to be stored in initial callback server provenance.
+	 * The parameters are JSON serializable.
+	 * 
+	 * @return the method parameters.
+	 */
+	public List<Object> getParams() {
+		return params;
+	}
+
+	/**
+	 * Get the workspace references to be stored in initial callback server provenance.
+	 * @return an list of workspace reference strings in the standard ws/obj/ver format.
+	 */
+	public List<String> getWorkspaceRefs() {
+		return workspaceRefs;
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(modulemethod, params, serviceVer, version, workspaceRefs);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CallbackProvenance other = (CallbackProvenance) obj;
+		return Objects.equals(modulemethod, other.modulemethod)
+				&& Objects.equals(params, other.params)
+				&& Objects.equals(serviceVer, other.serviceVer)
+				&& Objects.equals(version, other.version)
+				&& Objects.equals(workspaceRefs, other.workspaceRefs
+		);
+	}
+
+	/**
+	 * Get a builder for the {@link CallbackProvenance} class.
+	 *
+	 * @param modulemethod the module / method string for the SDK method to run,
+	 * e.g. "module.method".
+	 * @param version the version of the method to run.
+	 */
+	public static Builder getBuilder(final String modulemethod, final Version semver) {
+		return new Builder(modulemethod, semver);
+	}
+
+	/**
+	 * Builder for {@link CallbackProvenance}.
+	 */
+	public static final class Builder {
+		private final String modulemethod;
+		private final Version version;
+		private String serviceVer = "dev";
+		private List<Object> params = Collections.emptyList();
+		private List<String> workspaceRefs = Collections.emptyList();
+
+		private Builder(final String modulemethod, final Version semver) {
+			requireNonNull(semver, "semver");
+			requireNonNull(modulemethod, "modulemethod");
+			if (!MODULE_METHOD_PATTERN.matcher(modulemethod).matches()) {
+				throw new IllegalArgumentException("Invalid modulemethod: " + modulemethod);
+			}
+			this.modulemethod = modulemethod;
+			this.version = semver;
+		}
+
+		/**
+		 * Sets the service version to be stored in the initial callback server provenance.
+		 *
+		 * @param serviceVer "release", "beta", "dev", or a git hash
+		 * @return this Builder
+		 */
+		public Builder withServiceVer(final String serviceVer) {
+			if (!SERVICE_VER_PATTERN.matcher(requireNonNull(serviceVer, "serviceVer")).matches()) {
+				throw new IllegalArgumentException("Invalid service version: " + serviceVer);
+			}
+			this.serviceVer = serviceVer;
+			return this;
+		}
+
+		/**
+		 * Sets the params list to be stored in the initial callback server provenance.
+		 * 
+		 * Must be JSON serializable.
+		 *
+		 * @param params the parameters for the method to be stored.
+		 * @return this Builder
+		 */
+		public Builder withParams(final List<Object> params) {
+			if (params == null) {
+				this.params = Collections.emptyList();
+				return this;
+			}
+			try {
+				MAPPER.writeValueAsString(params);
+			} catch (JsonProcessingException e) {
+				throw new IllegalArgumentException("params are not JSON serializable", e);
+			}
+			this.params = new ArrayList<>(params);
+			return this;
+		}
+
+		/**
+		 * Sets the list of workspace references to be stored in the initial callback server
+		 * provenance.
+		 * 
+		 * References are in the standard format of ws/obj/ver.
+		 *
+		 * @param refs the references.
+		 * @return this Builder
+		 */
+		public Builder withWorkspaceRefs(final Collection<String> refs) {
+			if (refs == null) {
+				this.workspaceRefs = Collections.emptyList();
+				return this;
+			}
+			refs.stream()
+				.forEach(ref -> {
+					requireNonNull(ref, "workspace object ref");
+					// TODO CODE add more validation later, check ref structure
+				});
+			this.workspaceRefs = new ArrayList<>(refs);
+			return this;
+		}
+
+		/**
+		 * Builds the {@link CallbackProvenance} instance.
+		 *
+		 * @return the instance
+		 */
+		public CallbackProvenance build() {
+			return new CallbackProvenance(this);
+		}
+	}
+}

--- a/src/test/java/us/kbase/test/sdk/callback/CallbackProvenanceTest.java
+++ b/src/test/java/us/kbase/test/sdk/callback/CallbackProvenanceTest.java
@@ -1,0 +1,172 @@
+package us.kbase.test.sdk.callback;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.zafarkhaja.semver.Version;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.sdk.callback.CallbackProvenance;
+
+public class CallbackProvenanceTest {
+
+	@Test
+	public void equalsAndHashCodeContract() {
+		EqualsVerifier.forClass(CallbackProvenance.class).verify();
+	}
+	
+	@Test
+	public void buildMinimalValidInstance() {
+		final CallbackProvenance cp = CallbackProvenance
+				.getBuilder("module.method", Version.parse("1.0.0"))
+				.build();
+
+		assertThat(cp.getModuleMethod(), is("module.method"));
+		assertThat(cp.getVersion(), is(Version.parse("1.0.0")));
+		assertThat(cp.getServiceVer(), is("dev"));
+		assertThat(cp.getParams(), empty());
+		assertThat(cp.getWorkspaceRefs(), empty());
+	}
+	
+	@Test
+	public void buildMinimalValidInstanceOverwriteWithNulls() throws Exception {
+		final CallbackProvenance cp = CallbackProvenance
+				.getBuilder("module2.method2", Version.parse("1.0.0"))
+				.withParams(Arrays.asList("foo"))
+				.withWorkspaceRefs(Arrays.asList("1/2/3"))
+				.withParams(null)
+				.withWorkspaceRefs(null)
+				.build();
+
+		assertThat(cp.getModuleMethod(), is("module2.method2"));
+		assertThat(cp.getVersion(), is(Version.parse("1.0.0")));
+		assertThat(cp.getServiceVer(), is("dev"));
+		assertThat(cp.getParams(), empty());
+		assertThat(cp.getWorkspaceRefs(), empty());
+	}
+
+	@Test
+	public void buildFullValidInstance() throws Exception {
+		final CallbackProvenance cp = CallbackProvenance
+				.getBuilder("f_oo.ba_r", Version.parse("2.3.4"))
+				.withServiceVer("release")
+				.withParams(Arrays.asList("x", 123))
+				.withWorkspaceRefs(Arrays.asList("1/1/3", "w._-s1/ob|._-j1/15", "65/143154/1"))
+				.build();
+
+		assertThat(cp.getModuleMethod(), is("f_oo.ba_r"));
+		assertThat(cp.getVersion(), is(Version.parse("2.3.4")));
+		assertThat(cp.getServiceVer(), is("release"));
+		assertThat(cp.getParams(), contains("x", 123));
+		assertThat(cp.getWorkspaceRefs(), contains("1/1/3", "w._-s1/ob|._-j1/15", "65/143154/1"));
+	}
+	
+	@Test
+	public void serviceVerVariations() {
+		final List<String> testCases = Arrays.asList(
+				"dev", "beta", "release", "7f8e19a", "ed2ceca5db5fdd3e69ba619bc901e9eaf3d4da0d"
+		);
+		for (final String t: testCases) {
+			final CallbackProvenance cp = CallbackProvenance
+					.getBuilder("module.method", Version.parse("1.0.0"))
+					.withServiceVer(t)
+					.build();
+			assertThat(cp.getServiceVer(), is(t));
+		}
+	}
+
+	@Test
+	public void moduleMethodValidationFails() {
+		Exception e = assertThrows(NullPointerException.class,
+				() -> CallbackProvenance.getBuilder(null, Version.parse("1.0.0"))
+		);
+		assertThat(e.getMessage(), is("modulemethod"));
+
+		final List<String> testCases = Arrays.asList(
+				"foo", "foo$bar.meth", "bad method", "goodness.gra*cious"
+		);
+		for (final String t: testCases) {
+			e = assertThrows(IllegalArgumentException.class,
+					() -> CallbackProvenance.getBuilder(t, Version.parse("1.0.0"))
+			);
+			assertThat(e.getMessage(), is("Invalid modulemethod: " + t));
+		}
+	}
+
+	@Test
+	public void semverValidationFails() {
+		final Exception e = assertThrows(NullPointerException.class,
+				() -> CallbackProvenance.getBuilder("mod.meth", null)
+		);
+		assertThat(e.getMessage(), is("semver"));
+	}
+
+	@Test
+	public void serviceVerValidationFails() {
+		Exception e = assertThrows(NullPointerException.class,
+				() -> CallbackProvenance.getBuilder("mod.meth", Version.parse("1.0.0"))
+							.withServiceVer(null)
+		);
+		assertThat(e.getMessage(), is("serviceVer"));
+
+		final List<String> testCases = Arrays.asList(
+				"not_valid", "7fa8af", "1234567u", "1".repeat(41)
+		);
+		for (final String t: testCases) {
+			e = assertThrows(IllegalArgumentException.class,
+					() -> CallbackProvenance.getBuilder("mod.meth", Version.parse("1.0.0"))
+								.withServiceVer(t)
+			);
+			assertThat(e.getMessage(), is("Invalid service version: " + t));	
+		}
+	}
+
+	@Test
+	public void paramsMustBeJsonSerializable() {
+		final Exception e = assertThrows(IllegalArgumentException.class, () -> {
+			CallbackProvenance.getBuilder("mod.meth", Version.parse("1.0.0"))
+				.withParams(Arrays.asList(new ByteArrayOutputStream()));
+		});
+		assertThat(e.getMessage(), is("params are not JSON serializable"));
+	}
+
+	@Test
+	public void refsValidationFails() {
+		Exception e = assertThrows(NullPointerException.class, () -> 
+				CallbackProvenance.getBuilder("mod.meth", Version.parse("1.0.0"))
+				.withWorkspaceRefs(Arrays.asList("foo", null, "bar"))
+		);
+		assertThat(e.getMessage(), is("workspace object ref"));
+	}
+
+	@Test
+	public void containersAreImmutable() throws Exception {
+		// make sure inputs are mutable, Arrays.asList() output is immutable
+		final List<Object> params = new LinkedList<>(Arrays.asList("x"));
+		final List<String> refs = new LinkedList<>(Arrays.asList("1/2/3"));
+
+		final CallbackProvenance cp = CallbackProvenance
+				.getBuilder("mod.meth", Version.parse("1.0.0"))
+				.withParams(params)
+				.withWorkspaceRefs(refs)
+				.build();
+
+		assertThrows(UnsupportedOperationException.class, () -> cp.getParams().add("y"));
+		assertThrows(
+				UnsupportedOperationException.class, () -> cp.getWorkspaceRefs().add("4/5/6")
+		);
+
+		assertThat(cp.getParams(), contains("x"));
+		assertThat(cp.getWorkspaceRefs(), contains("1/2/3"));
+	}
+}

--- a/src/test/java/us/kbase/test/sdk/callback/CallbackServerTest.java
+++ b/src/test/java/us/kbase/test/sdk/callback/CallbackServerTest.java
@@ -1,4 +1,4 @@
-package us.kbase.test.sdk.tester;
+package us.kbase.test.sdk.callback;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
This takes the place of the ModuleRunVersion class and the lists of params and ws refs. The new callback server manager will consume this class (coming up next).

Also move the callback server tests to the callback package to make them easier to review next time.