### PR TITLE
Optionally set callback server files to world writeable

### DIFF
--- a/src/test/java/us/kbase/test/sdk/callback/CallbackServerTest.java
+++ b/src/test/java/us/kbase/test/sdk/callback/CallbackServerTest.java
@@ -121,7 +121,8 @@ public class CallbackServerTest {
                 Files.createTempDirectory(TEST_DIR, "cbt"),
                 new URL(kBaseEndpoint),
                 token,
-                prov
+                prov,
+                true
         );
         // not really a lot that can be tested re getting the urls
         final String port = csm.getCallbackPort() + "";
@@ -304,7 +305,7 @@ public class CallbackServerTest {
             final String exmsg
             ) throws Exception {
         final Exception e = assertThrows(exclass,
-                () -> new CallbackServerManager(workdir, baseUrl, token, prov)
+                () -> new CallbackServerManager(workdir, baseUrl, token, prov, true)
         );
         assertThat(e.getMessage(), is(exmsg));
     }


### PR DESCRIPTION
The callback server and spawned contaeiners leaves root owned files on disk. This updates the CBS manager to optionally make them world writeable after stopping the CBS so they can be deleted.

The tests can now be run in succession, whereas before they would fail as they couldn't clean up the prior tests' files.