### PR TITLE
Update ModuleTester to use the python callback server

### DIFF
--- a/src/main/java/us/kbase/sdk/ModuleBuilder.java
+++ b/src/main/java/us/kbase/sdk/ModuleBuilder.java
@@ -433,7 +433,8 @@ public class ModuleBuilder implements Runnable{
 		public Integer call() {
 			try {
 				final ModuleTester tester = new ModuleTester();
-				return tester.runTests(skipValidation);
+				// TODO CBS add arg to set files globally writeable. add WARNING
+				return tester.runTests(skipValidation, false);
 			}
 			catch (Exception e) {
 				showError("Error while testing module", e.getMessage());

--- a/src/main/java/us/kbase/sdk/tester/ModuleTester.java
+++ b/src/main/java/us/kbase/sdk/tester/ModuleTester.java
@@ -12,33 +12,20 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.productivity.java.syslog4j.SyslogIF;
 
-import us.kbase.common.executionengine.CallbackServer;
-import us.kbase.common.executionengine.LineLogger;
-import us.kbase.common.executionengine.ModuleMethod;
-import us.kbase.common.executionengine.ModuleRunVersion;
-import us.kbase.common.executionengine.CallbackServerConfigBuilder.CallbackServerConfig;
-import us.kbase.common.service.JsonServerServlet;
-import us.kbase.common.service.JsonServerSyslog;
-import us.kbase.common.service.JsonServerSyslog.SyslogOutput;
-import us.kbase.common.service.UObject;
-import us.kbase.common.utils.NetUtils;
+import com.github.zafarkhaja.semver.Version;
+
+import us.kbase.sdk.callback.CallbackProvenance;
+import us.kbase.sdk.callback.CallbackServerManager;
 import us.kbase.sdk.common.KBaseYmlConfig;
 import us.kbase.sdk.common.TestLocalManager;
 import us.kbase.sdk.common.TestLocalManager.TestLocalInfo;
@@ -83,7 +70,8 @@ public class ModuleTester {
         }
     }
     
-    public int runTests(final boolean skipValidation) throws Exception {
+    public int runTests(final boolean skipValidation, final boolean setFilesGloballyWriteable
+        ) throws Exception {
         // TODO CODE some of this code looks similar to that in the module runner, DRY possible
         final TestLocalInfo tli = TestLocalManager.ensureTestLocal(
                 moduleDir.toPath(),
@@ -157,77 +145,27 @@ public class ModuleTester {
         if (!buildNewDockerImageWithCleanup(moduleDir, tlDir, runDockerSh, imageName))
             return 1;
         ///////////////////////////////////////////////////////////////////////////////////////////
-        int callbackPort = NetUtils.findFreePort();
-        String[] callbackNetworks = null;
-        String callbackNetworksText = props.getProperty("callback_networks");
-        if (callbackNetworksText != null) {
-            callbackNetworks = callbackNetworksText.trim().split("\\s*,\\s*");
-            System.out.println("Custom network instarface list is defined: " + 
-                    Arrays.asList(callbackNetworks));
-        }
-        URL callbackUrl = CallbackServer.getCallbackUrl(callbackPort, callbackNetworks);
-        Server jettyServer = null;
-        if (callbackUrl != null) {
-            JsonServerSyslog.setStaticUseSyslog(false);
-            CallbackServerConfig cfg = cfgLoader.buildCallbackServerConfig(callbackUrl, 
-                    tlDir.toPath(), new LineLogger() {
-                @Override
-                public void logNextLine(String line, boolean isError) {
-                    if (isError) {
-                        System.err.println(line);
-                    } else {
-                        System.out.println(line);
-                    }
-                }
-            });
-            ModuleRunVersion runver = new ModuleRunVersion(
-                    new URL("https://localhost"),
-                    new ModuleMethod(moduleName + ".run_local_tests"),
-                    "local-docker-image", "local", "dev");
-            final DockerMountPoints mounts = new DockerMountPoints(
-                    Paths.get("/kb/module/work"), Paths.get("tmp"));
-            Map<String, String> localModuleToImage = new LinkedHashMap<>();
-            localModuleToImage.put(moduleName, imageName);
-            JsonServerServlet catalogSrv = new SDKCallbackServer(
-                    cfgLoader.getToken(), cfg, runver, new ArrayList<UObject>(),
-                    new ArrayList<String>(), mounts, localModuleToImage);
-            catalogSrv.changeSyslogOutput(new SyslogOutput() {
-                @Override
-                public void logToSystem(
-                       final SyslogIF log,
-                       final int level,
-                       final String message) {
-                   System.out.println(message);
-                }
-            });
-            jettyServer = new Server(callbackPort);
-            ServletContextHandler context = new ServletContextHandler(
-                    ServletContextHandler.SESSIONS);
-            context.setContextPath("/");
-            jettyServer.setHandler(context);
-            context.addServlet(new ServletHolder(catalogSrv),"/*");
-            jettyServer.start();
-        } else {
-            if (callbackNetworks != null && callbackNetworks.length > 0) {
-                throw new IllegalStateException("No proper callback IP was found, " +
-                		"please check callback_networks parameter in test.cfg");
-            }
-            System.out.println("WARNING: No callback URL was received " +
-                    "by the job runner. Local callbacks are disabled.");
-        }
-        ///////////////////////////////////////////////////////////////////////////////////////////
-        try {
-            System.out.println();
+        final CallbackServerManager csm = new CallbackServerManager(
+                tlDir.toPath(),
+                new URL(cfgLoader.getEndPoint()),
+                cfgLoader.getToken(),
+                CallbackProvenance.getBuilder(moduleName + ".run_local_tests", Version.of(0, 1, 0))
+                        .withCodeUrl(new URL("http://localhost"))
+                        .build(),
+                setFilesGloballyWriteable
+        );
+        System.out.println(String.format("Local callback port: %s", csm.getCallbackPort()));
+        System.out.println(String.format(
+                "In container callback url: %s", csm.getInContainerCallbackUrl())
+        );
+        try (csm) {
             ProcessHelper.cmd("chmod", "+x", runTestsSh.getCanonicalPath()).exec(tlDir);
-            int exitCode = ProcessHelper.cmd("bash", DirUtils.getFilePath(runTestsSh),
-                    callbackUrl == null ? "http://fakecallbackurl" : 
-                        callbackUrl.toExternalForm()).exec(tlDir).getExitCode();
+            int exitCode = ProcessHelper.cmd(
+                    "bash",
+                    DirUtils.getFilePath(runTestsSh),
+                    csm.getInContainerCallbackUrl().toExternalForm()
+            ).exec(tlDir).getExitCode();
             return exitCode;
-        } finally {
-            if (jettyServer != null) {
-                System.out.println("Shutting down callback server...");
-                jettyServer.stop();
-            }
         }
     }
 

--- a/src/test/java/us/kbase/test/sdk/TestUtils.java
+++ b/src/test/java/us/kbase/test/sdk/TestUtils.java
@@ -3,74 +3,25 @@ package us.kbase.test.sdk;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 
-import us.kbase.sdk.util.ProcessHelper;
 import us.kbase.test.sdk.scripts.TestConfigHelper;
 
 /** Yes I know utility classes are bad etc etc */
 
 public class TestUtils {
 	
-	/** Set docker output owned by root to publicly readable, writable, and executable.
-	 * 
-	 * Some tests leave files that can only be written to by root on the drive.
-	 * 
-	 * @param moduleRoot the root of the module to modify.
-	 * @param target the directory to recursively alter, relative to /kb/module/work in the
-	 * container, where test_local/workdir is mounted.
-	 * @param ignoreMissing do nothing if the target directory does not exist or is not a
-	 * directory. Otherwise an error may be thrown.
-	 * 
-	 * @throws Exception if an error occurs.
-	 */
-	public static void makeDockerOutputWritable(
-			final Path moduleRoot,
-			final Path target,
-			boolean ignoreMissing)
-			throws Exception {
-		final Path workdir = moduleRoot.resolve("test_local/workdir");
-		final Path lclTarget = workdir.resolve(target).toAbsolutePath();
-		if (ignoreMissing && (!Files.exists(lclTarget) || !Files.isDirectory(lclTarget))) {
-			return;
-		}
-		final Path tgt = Paths.get("/kb/module/work").resolve(target);
-		final int exitCode = ProcessHelper.cmd(
-				"docker", "run",
-				"--rm",
-				"-v", workdir.toRealPath().toString() + ":/kb/module/work",
-				"--entrypoint", "chmod",
-				// use an image that'll be used for the tests anyway
-				// should be updated if dockerfile template changes
-				"kbase/sdkbase2:latest", 
-				"-R", "o+rwx", tgt.toString()
-		).exec(moduleRoot.toFile()).getExitCode();
-		if (exitCode != 0) {
-			throw new IllegalStateException(
-					"Setting permissions on root owned files failed with exit code " + exitCode
-			);
-		}
-	}
-	
 	/** Delete an SDK module. Does nothing if the module path doesn't exist or isn't a directory.
 	 * @param module the path to the module root.
-	 * @param makeWriteable true if the module is expected to have root owned data
-	 * in test_local/workdir, which will be set to world writable depending on the
-	 * test configuration file.
 	 * @param deleteModule if false, the module won't be deleted.
 	 * @throws Exception if an error occurs
 	 */
 	public static void deleteTestModule(
 			final Path module,
-			boolean makeWriteable,
-			boolean deleteModule)
-			throws Exception {
+			boolean deleteModule
+			) throws Exception {
 		if (Files.exists(module) && Files.isDirectory(module)) {
-			if (TestConfigHelper.getMakeRootOwnedFilesWriteable() && makeWriteable) {
-				TestUtils.makeDockerOutputWritable(module, Paths.get("."), true);
-			}
 			if (deleteModule) {
 				try {
 					System.out.println("Deleting " + module);

--- a/src/test/java/us/kbase/test/sdk/tester/ModuleTesterTest.java
+++ b/src/test/java/us/kbase/test/sdk/tester/ModuleTesterTest.java
@@ -41,7 +41,7 @@ public class ModuleTesterTest {
 	@AfterAll
 	public static void tearDownModule() throws Exception {
 		for (final Path mod: CREATED_MODULES) {
-			TestUtils.deleteTestModule(mod, true, DELETE_TEST_MODULES);
+			TestUtils.deleteTestModule(mod, DELETE_TEST_MODULES);
 		}
 	}
 
@@ -52,7 +52,7 @@ public class ModuleTesterTest {
 
 	private Path init(final String lang, final String moduleName) throws Exception {
 		final Path workDir = Paths.get(TestConfigHelper.getTempTestDir(), moduleName);
-		TestUtils.deleteTestModule(workDir, true, true);
+		TestUtils.deleteTestModule(workDir, true);
 		CREATED_MODULES.add(workDir);
 		TestUtils.createSdkCfgFile(Paths.get(TestConfigHelper.getTempTestDir()), moduleName);
 		new ModuleInitializer(
@@ -87,7 +87,9 @@ public class ModuleTesterTest {
 				"auth_service_url_allow_insecure=" + 
 				TestConfigHelper.getAuthServiceUrlInsecure() + "\n";
 		FileUtils.writeStringToFile(testCfgFile, testCfgText);
-		int exitCode = new ModuleTester(moduleDir).runTests(skipValidation);
+		int exitCode = new ModuleTester(moduleDir).runTests(
+				skipValidation, TestConfigHelper.getMakeRootOwnedFilesWriteable()
+		);
 		System.out.println("Exit code: " + exitCode);
 		return exitCode;
 	}
@@ -168,62 +170,4 @@ public class ModuleTesterTest {
 		assertEquals(2, exitCode);
 	}
 
-	@Test
-	public void testSelfCalls() throws Exception {
-		System.out.println("Test [testSelfCalls]");
-		String lang = "python";
-		String moduleName = SIMPLE_MODULE_NAME + "Self";
-		final Path workDir = Paths.get(TestConfigHelper.getTempTestDir(), moduleName);
-		TestUtils.deleteTestModule(workDir, true, true);
-		CREATED_MODULES.add(workDir);
-		String implInit = "" +
-				"#BEGIN_HEADER\n" +
-				"import os\n"+
-				"from " + moduleName + "." + moduleName + "Client import " + moduleName + " as local_client\n" +
-				"#END_HEADER\n" +
-				"\n" +
-				"    #BEGIN_CLASS_HEADER\n" +
-				// TODO TESTHACK PYTEST upgrade to pytest and remove this line assuming that works
-				"    __test__ = False\n" + // nose is identifying the class as a test case
-				"    #END_CLASS_HEADER\n" +
-				"\n" +
-				"        #BEGIN_CONSTRUCTOR\n" +
-				"        #END_CONSTRUCTOR\n" +
-				"\n" +
-				"        #BEGIN run_local\n" +
-				"        returnVal = local_client(os.environ['SDK_CALLBACK_URL']).calc_square(input)\n" +
-				"        #END run_local\n" +
-				"\n" +
-				"        #BEGIN calc_square\n" +
-				"        returnVal = input * input\n" +
-				"        #END calc_square\n";
-		File moduleDir = workDir.toFile();
-		File implFile = new File(moduleDir, "lib/" + moduleName + "/" + moduleName + "Impl.py");
-		TestUtils.createSdkCfgFile(Paths.get(TestConfigHelper.getTempTestDir()), moduleName);
-		new ModuleInitializer(
-				moduleName,
-				token.getUserName(),
-				lang,
-				false,
-				new File(TestConfigHelper.getTempTestDir()),
-				true
-		).initialize(false);
-		File specFile = new File(moduleDir, moduleName + ".spec");
-		String specText = FileUtils.readFileToString(specFile).replace("};", 
-				"funcdef run_local(int input) returns (int) authentication required;\n" +
-				"funcdef calc_square(int input) returns (int) authentication required;\n" +
-				"};");
-		File testFile = new File(moduleDir, "test/" + moduleName + "_server_test.py");
-		final String testCode = FileUtils.readFileToString(testFile);
-		final int index = testCode.indexOf("    def test_your_method(self)");
-		final String newCode = testCode.substring(0, index)
-				+ "    def test_your_method(self):\n"
-				+ "        self.assertEqual(25, self.serviceImpl.run_local(self.ctx, 5)[0])\n";
-		assertThat(testCode, is(not(newCode)));
-		FileUtils.writeStringToFile(specFile, specText);
-		FileUtils.writeStringToFile(implFile, implInit);
-		FileUtils.writeStringToFile(testFile, newCode);
-		int exitCode = runTestsInDocker(moduleDir, token, true);
-		assertEquals(0, exitCode);
-	}
 }


### PR DESCRIPTION
Removes a test that tests a local module calling the local version of itself as the Python callback server doesn't support that