### PR TITLE
Update the ModuleRunner to use the CallbackServerManager.

### DIFF
--- a/src/main/java/us/kbase/sdk/ModuleBuilder.java
+++ b/src/main/java/us/kbase/sdk/ModuleBuilder.java
@@ -599,10 +599,14 @@ public class ModuleBuilder implements Runnable{
 				paramLabel = "<sdk_home_dir>",
 				names = {"-h", "--sdk-home"},
 				description = """
-						The folder containing the sdk.cfg and run_local folders. If they do \
-						not exist, they will be created. The default is loaded from the \
-						KB_SDK_HOME environment variable, which must be set if this \
-						argument is not supplied.\
+						The folder containing the sdk.cfg and run_local folders. \
+						If they do not exist, they will be created. The default is loaded \
+						from the KB_SDK_HOME environment variable, which must be set if this \
+						argument is not supplied. \
+						Any input files must be placed in run_local/workdir/tmp for them to \
+						be visible to the SDK module containers. "workdir" will be mounted into \
+						the containers at "/kb/module/work", so any input file paths in the \
+						method input must be prefixed with "/kb/module/work/tmp/".
 						"""
 		)
 		Path sdkHome;
@@ -617,20 +621,6 @@ public class ModuleBuilder implements Runnable{
 						"""
 		)
 		String provRefs;
-
-		@Option(
-				paramLabel = "<mount_points>",
-				names = {"-m","--mount-points"},
-				description = """
-						A comma separated list of mount points for the docker container. \
-						Each mount point consists of a local file path, a colon (:) separator, \
-						and a file path inside the docker container that is the target of the \
-						local mount. A relative docker container path is treated as relative to \
-						/kb/module/work. If the colon separator and docker container path are \
-						omitted the local path is mounted to /kb/module/work/tmp.\
-						"""
-		)
-		String mountPoints;
 
 		@Parameters(
 				paramLabel = "<method_name>",
@@ -655,8 +645,9 @@ public class ModuleBuilder implements Runnable{
 						tagVer,
 						verbose,
 						keepTempFiles,
-						provRefs, 
-						mountPoints
+						provRefs,
+						// TODO CBS add arg to to set files globally writeable. add WARNING
+						false
 				);
 			} catch (Exception e) {
 				showError("Error while running method", e.getMessage());

--- a/src/main/java/us/kbase/sdk/callback/CallbackServerManager.java
+++ b/src/main/java/us/kbase/sdk/callback/CallbackServerManager.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import us.kbase.auth.AuthToken;
 import us.kbase.common.utils.NetUtils;
 
-// TODO CBS convert module runner and tester
 // TODO CBS delete old callback server code and related code
 
 // could probably make it work in a container if we really needed to, but it'd need to know that

--- a/src/main/java/us/kbase/sdk/tester/ConfigLoader.java
+++ b/src/main/java/us/kbase/sdk/tester/ConfigLoader.java
@@ -3,17 +3,12 @@ package us.kbase.sdk.tester;
 import java.io.File;
 import java.io.PrintWriter;
 import java.net.URI;
-import java.net.URL;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
 
 import us.kbase.auth.AuthToken;
 import us.kbase.auth.client.AuthClient;
-import us.kbase.common.executionengine.CallbackServerConfigBuilder;
-import us.kbase.common.executionengine.CallbackServerConfigBuilder.CallbackServerConfig;
-import us.kbase.common.executionengine.LineLogger;
 
 public class ConfigLoader {
     private final String authUrl;
@@ -136,14 +131,6 @@ public class ConfigLoader {
         } finally {
             pw.close();
         }
-    }
-    
-    public CallbackServerConfig buildCallbackServerConfig(
-            URL callbackUrl, Path workDir, LineLogger logger) throws Exception {
-        return new CallbackServerConfigBuilder(
-                new URL(endPoint), new URL(wsUrl), new URL(shockUrl), new URL(jobSrvUrl),
-                new URL(handleUrl), new URL(srvWizUrl), new URL(njswUrl), new URL(authUrl),
-                authAllowInsecure, new URL(catalogUrl), callbackUrl, workDir, null, logger).build();
     }
     
     private static String getConfigUrl(Properties props, String key, String endPoint, 


### PR DESCRIPTION
There's no tests for the MR so this was tested manually.

The mount option was removed from the run command for two reasons:

* The Python callback server doesn't support user specified mounts
* User mounts don''t necessarily work. If a SDK module tries to hardlink an input file from a user mount to the scratch directory, it will fail as that appears to be a inter-device mount to the docker image. The only way to ensure that hardlinks work is by putting the input files in the scratch directory, which makes them visible to all other containers as well.

The drawback is that we can no longer safely clean up the workdir directory as it may contain input files from the user.