### PR TITLE
Fix python server overquoting

### DIFF
--- a/src/main/resources/us/kbase/sdk/templates/python_server.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/python_server.vm.properties
@@ -130,7 +130,13 @@ class JSONRPCServiceCustom(JSONRPCService):
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
             if len(e.args) == 1:
-                newerr.data = repr(e.args[0])
+                # repr adds single quotes around string arguments which is not what we want.
+                if isinstance(e.args[0], str):
+                    # this is pretty much the only case that regularly happens
+                    # not sure if the other two cases happen anywhere in KBase
+                    newerr.data = str(e.args[0])
+                else:
+                    newerr.data = repr(e.args[0])
             else:
                 newerr.data = repr(e.args)
             raise newerr

--- a/src/test/java/us/kbase/test/sdk/scripts/TypeGeneratorTest.java
+++ b/src/test/java/us/kbase/test/sdk/scripts/TypeGeneratorTest.java
@@ -326,9 +326,6 @@ public class TypeGeneratorTest {
 
 	@Test
 	public void testAsyncMethods() throws Exception {
-		// TODO PYTHONSERVER Revert the change that causes errors to be repr'd rather than
-		//                   str'd. Causes extra quotes around the string, which made this
-		//                   test fail. Fix Test12.java.properties when done.
 		// TODO TESTREINSTATEMENT see the comments in test12.spec.properties
 		int testNum = 12;
 		File workDir = prepareWorkDir(testNum);

--- a/src/test/resources/us/kbase/test/sdk/scripts/Test12.java.properties
+++ b/src/test/resources/us/kbase/test/sdk/scripts/Test12.java.properties
@@ -35,12 +35,7 @@ public class Test12 {
             client.throwErrorOnServerSide("Special async error");
             Assert.fail("Method shouldn't work because there is an exception on server side");
         } catch (Throwable ex) {
-            // TODO PYTHONSERVER Revert the change that causes errors to be repr'd rather than
-            //                   str'd. Causes extra quotes around the string.
-            String msg = "Special async error";
-            boolean pass = ex.getMessage().equals(msg) || ex.getMessage().equals("'" + msg + "'");
-            Assert.assertTrue("See test code for error, sigh", pass);
-            //Assert.assertEquals("'Special async error'", ex.getMessage());
+            Assert.assertEquals("Special async error", ex.getMessage());
         }
 	}
 	


### PR DESCRIPTION
repr adds superfluous single quotes to strings