### PR TITLE
Fix python server "output not found" error

### DIFF
--- a/src/main/resources/us/kbase/sdk/templates/python_server.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/python_server.vm.properties
@@ -597,29 +597,28 @@ def stop_server():
 
 def process_async_cli(input_file_path, output_file_path, token):
     exit_code = 0
-    with open(input_file_path) as data_file:
-        req = json.load(data_file)
-    if 'version' not in req:
-        req['version'] = '1.1'
-    if 'id' not in req:
-        req['id'] = str(_random.random())[2:]
-    ctx = MethodContext(application.userlog)
-#if( $authenticated )
-    if token:
-        user = application.auth_client.get_user(token)
-        ctx['user_id'] = user
-        ctx['authenticated'] = 1
-        ctx['token'] = token
-#end
-    if 'context' in req:
-        ctx['rpc_context'] = req['context']
-    ctx['CLI'] = 1
-    ctx['module'], ctx['method'] = req['method'].split('.')
-    prov_action = {'service': ctx['module'], 'method': ctx['method'],
-                   'method_params': req['params']}
-    ctx['provenance'] = [prov_action]
-    resp = None
     try:
+        with open(input_file_path) as data_file:
+            req = json.load(data_file)
+        if 'version' not in req:
+            req['version'] = '1.1'
+        if 'id' not in req:
+            req['id'] = str(_random.random())[2:]
+        ctx = MethodContext(application.userlog)
+#if( $authenticated )
+        if token:
+            user = application.auth_client.get_user(token)
+            ctx['user_id'] = user
+            ctx['authenticated'] = 1
+            ctx['token'] = token
+#end
+        if 'context' in req:
+            ctx['rpc_context'] = req['context']
+        ctx['CLI'] = 1
+        ctx['module'], ctx['method'] = req['method'].split('.')
+        prov_action = {'service': ctx['module'], 'method': ctx['method'],
+                       'method_params': req['params']}
+        ctx['provenance'] = [prov_action]
         resp = application.rpc_service.call_py(ctx, req)
     except JSONRPCError as jre:
         trace = jre.trace if hasattr(jre, 'trace') else None
@@ -630,13 +629,13 @@ def process_async_cli(input_file_path, output_file_path, token):
                           'message': jre.data,
                           'error': trace}
                 }
-    except Exception:
+    except Exception as e:
         trace = traceback.format_exc()
         resp = {'id': req['id'],
                 'version': req['version'],
                 'error': {'code': 0,
-                          'name': 'Unexpected Server Error',
-                          'message': 'An unexpected server error occurred',
+                          'name': 'Unexpected Error',
+                          'message': f"An unexpected error occurred: {e}",
                           'error': trace}
                 }
     if 'error' in resp:

--- a/src/test/resources/us/kbase/test/sdk/scripts/Test12.java.properties
+++ b/src/test/resources/us/kbase/test/sdk/scripts/Test12.java.properties
@@ -37,6 +37,36 @@ public class Test12 {
         } catch (Throwable ex) {
             Assert.assertEquals("Special async error", ex.getMessage());
         }
+
+        // test that app fails correctly on an early error, in this case a bad token
+        token = new AuthToken("faketoken", "<unknown>");
+        client = new AsyncMethodsClient(new URL("http://localhost:" + port), token);
+        client.setIsInsecureHttpConnectionAllowed(true);
+        if (System.getProperty("KB_JOB_CHECK_WAIT_TIME") != null) {
+            client.setAsyncJobCheckTimeMs(Long.parseLong(
+                System.getProperty("KB_JOB_CHECK_WAIT_TIME")
+            ));
+        }
+        String pyerr = "An unexpected error occurred: Error connecting to auth service: "
+            + "401 Unauthorized\n10020 Invalid token";
+        String javaerr = "Token validation failed: Auth service returned an error: "
+            + "10020 Invalid token";
+        try {
+            client.getOneObject(list1);
+            Assert.fail("expected exception");
+        } catch (Throwable ex) {
+            boolean pass = ex.getMessage().equals(pyerr) || ex.getMessage().equals(javaerr);
+            Assert.assertTrue(
+                String.format(
+                    "Token error did not match either the python or java format:\n"
+                    + "    got:    %s\n"
+                    + "    python: %s\n"
+                    + "    java:   %s\n",
+                    ex.getMessage(), pyerr, javaerr
+                ),
+                pass
+            );
+        }
 	}
 	
 	public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Should now catch any error and write the output file unless it can't write the output file at all

Hiding whitespace makes the review easier

Fixes #14 