### PR TITLE
Prep for base-image-less SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,6 +268,18 @@ graalvmNative {
 				'--enable-url-protocols=https,http',
 				'-H:+AddAllCharsets'
 			])
+			
+			def arch = System.getProperty("os.arch")
+			println "Detected architecture: ${arch}"
+
+			if (arch == "x86_64" || arch == "amd64") {
+				println "Adding -march=x86-64-v2 to build args"
+				// the KBase CI catalog service hardware is oooooold
+				// TODO KBASE_HW remove this stuff if we ever get modern HW
+				buildArgs.add("-march=x86-64-v2")
+			} else {
+				println "Skipping -march option for architecture: ${arch}"
+			}
 		}
 	}
 }

--- a/src/main/java/us/kbase/sdk/compiler/TemplateBasedGenerator.java
+++ b/src/main/java/us/kbase/sdk/compiler/TemplateBasedGenerator.java
@@ -76,6 +76,10 @@ public class TemplateBasedGenerator {
             pythonClient.close();
         }
         //////////////////////////////////////// Servers /////////////////////////////////////////
+        // AFAICT at this pint either
+        //     * the python server name is null and getPythonServer is false
+        //     * the python server name is supplied and getPythonServer is true
+        // so one implies the other
         if (pythonServerName != null) {
             String pythonServerPath = fixPath(pythonServerName, ".") + ".py";
             initPythonPackages(pythonServerPath, output, false);
@@ -184,6 +188,8 @@ public class TemplateBasedGenerator {
         copyResourceFile(relativePyPath, output, "authclient.py");
         if (client) {
             copyResourceFile(relativePyPath, output, "baseclient.py");
+        } else {
+            copyResourceFile("biokbase/log.py", output, "log.py");
         }
     }
 
@@ -199,9 +205,10 @@ public class TemplateBasedGenerator {
             filepath = Paths.get(relativePath).getParent()
                     .resolve(file);
         }
-        try (final InputStream input =
-                TemplateFormatter.getResource(file);
-             final Writer w = output.openWriter(filepath.toString())) {
+        try (
+            final InputStream input = TemplateFormatter.getResource(file);
+            final Writer w = output.openWriter(filepath.toString())
+        ) {
             IOUtils.copy(input, w);
         }
     }


### PR DESCRIPTION
This commit lays the groundwork for SDK Dockerfiles that don't use base images.

* It downgrades the CPU instructions for the binary build to a level that's compatible with the CI catalog service HW.
* It puts the log.py file into lib/biokbase rather than depending on the base image in a compile.