### PR TITLE
Eliminate python base image

### DIFF
--- a/src/main/resources/us/kbase/sdk/templates/module_docker_entrypoint.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_docker_entrypoint.vm.properties
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-. /kb/deployment/user-env.sh
-
 python ./scripts/prepare_deploy_cfg.py ./deploy.cfg ./work/config.properties
 
 if [ -f ./work/token ] ; then

--- a/src/main/resources/us/kbase/sdk/templates/module_dockerfile.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_dockerfile.vm.properties
@@ -1,9 +1,43 @@
-#if( $language == "python")
-FROM kbase/sdkbase2:python
+#if($language == "python")
+FROM python:3.12-trixie
 #else
 FROM kbase/sdkbase2:latest
 #end
-MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
+LABEL maintainer=#if($username)${username}#{else}"KBase Developer"#{end}
+
+#if($language == "python")
+# -----------------------------------------
+# Set up SDK requirements
+
+# In this section, we install code required for the SDK to run.
+
+# Don't spam the KBase Catalog logs
+ENV PIP_PROGRESS_BAR=off
+
+# Install general binaries
+RUN apt update && apt install -y wget
+
+# Install the SDK binary. This is required for spec compilation and catalog registration.
+ENV SDK_VER=0.1.0-alpha4
+ENV SDK_SHA=abd85762e5ec9c56533e77639b4367cf2e0762971c5c58589bf8d96ffb203e55
+RUN mkdir -p /sdk/bin \
+    && wget -q -O /sdk/bin/kb-sdk https://github.com/kbase/kb_sdk_plus/releases/download/$SDK_VER/kb-sdk-linux-x64 \
+    && echo "$SDK_SHA /sdk/bin/kb-sdk" | sha256sum --check \
+    && chmod a+x /sdk/bin/kb-sdk
+ENV PATH=/sdk/bin:$PATH
+
+# Install python libraries required by the SDK code.
+# You may wish to use a dependency manager like pipenv or uv to install
+# these as well as your own dependencies.
+# Note uwsgi can be removed if this module is not a dynamic service, which is usually the case
+RUN pip install \
+    requests==2.32.5 \
+    jsonrpcbase==0.2.0 \
+    jinja2==3.1.6 \
+    uwsgi==2.0.30 \
+    pytest==8.4.2 \
+    pytest-cov==6.2.1
+#end
 
 # -----------------------------------------
 # In this section, you can install any system dependencies required
@@ -13,10 +47,15 @@ MAINTAINER #if($username)${username}#{else}KBase Developer#{end}
 
 # RUN apt-get update
 
-#if($example && $language == "java")
+#if($example)
+#if($language == "python")
+# Install BioPython for the application
+RUN pip install biopython==1.85
+#else
 # download a fasta reader/writer
 RUN cd /kb/deployment/lib/jars \
     && wget https://downloads.sourceforge.net/project/jfasta/releases/jfasta-2.2.0/jfasta-2.2.0-jar-with-dependencies.jar
+#end
 #end
 
 # -----------------------------------------

--- a/src/main/resources/us/kbase/sdk/templates/module_makefile.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_makefile.vm.properties
@@ -21,6 +21,8 @@ ANT_HOME ?= $(KB_RUNTIME)/ant
 ANT = $(ANT_HOME)/bin/ant
 #end
 
+TEST_SPEC = .
+
 .PHONY: test
 
 default: compile
@@ -86,7 +88,7 @@ build-test-script:
 #if($language == "python")
 	echo 'export PYTHONPATH=$$script_dir/../$(LIB_DIR):$$PATH:$$PYTHONPATH' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'python -m nose --with-coverage --cover-package=$(SERVICE_CAPS) --cover-html --cover-html-dir=/kb/module/work/test_coverage --nocapture  --nologcapture .' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'pytest  -vv --cov=$(SERVICE_CAPS) --cov-report=html:/kb/module/work/test_coverage --cov-report=xml:/kb/module/work/coverage.xml $(TEST_SPEC)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #end
 #if($language == "java")
 	echo 'export JAVA_HOME=$(JAVA_HOME)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)

--- a/src/main/resources/us/kbase/sdk/templates/module_prepare_deploy_cfg.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_prepare_deploy_cfg.vm.properties
@@ -39,7 +39,11 @@ if __name__ == "__main__":
             if key.startswith('KBASE_SECURE_CONFIG_PARAM_'):
                 param_name = key[len('KBASE_SECURE_CONFIG_PARAM_'):]
                 props += param_name + " = " + os.environ.get(key) + "\n"
-        config.readfp(StringIO(props))
+        # TODO BASEIMAGE remove when updating java docker file to py3
+        if hasattr(config, "read_file"):
+            config.read_file(StringIO(props))   # Python 3
+        else:
+            config.readfp(StringIO(props))   # Python 2 - Remove after updating java base image
     else:
         raise ValueError('Neither ' + sys.argv[2] + ' file nor KBASE_ENDPOINT env-variable found')
     props = dict(config.items("global"))

--- a/src/test/java/us/kbase/test/sdk/scripts/TypeGeneratorTest.java
+++ b/src/test/java/us/kbase/test/sdk/scripts/TypeGeneratorTest.java
@@ -628,13 +628,7 @@ public class TypeGeneratorTest {
 			//JavaTypeGenerator.checkEnvVars(lines, "PYTHONPATH");
 			lines.addAll(Arrays.asList(
 					"export KB_DEPLOYMENT_CONFIG=" + cfgFile.getCanonicalPath(),
-					"cd \"" + serverOutDir.getAbsolutePath() + "\"",
-					"if [ ! -d biokbase ]; then",
-					"  mkdir -p ./biokbase",
-					// TODO TESTCODE this is bonkers, need a better way of reffing files
-					"  cp -r ../../../../src/main/resources/us/kbase/sdk/templates/log.py "
-					+ "./biokbase/",
-					"fi"
+					"cd \"" + serverOutDir.getAbsolutePath() + "\""
 					));
 			if (serverPortNum != null) {
 				lines.addAll(Arrays.asList(

--- a/src/test/java/us/kbase/test/sdk/tester/ModuleTesterTest.java
+++ b/src/test/java/us/kbase/test/sdk/tester/ModuleTesterTest.java
@@ -100,19 +100,6 @@ public class ModuleTesterTest {
 		String lang = "python";
 		String moduleName = SIMPLE_MODULE_NAME + "Python";
 		final Path moduleDir = init(lang, moduleName);
-		// TODO TESTHACK PYTEST upgrade to pytest and remove this stuff assuming that works
-		// nose is identifying the class as a test case
-		final Path implFile = moduleDir.resolve(
-				Paths.get("lib", moduleName, moduleName + "Impl.py")
-		);
-		final String implText = FileUtils.readFileToString(implFile.toFile());
-		final String newText = implText.replace("    #BEGIN_CLASS_HEADER", 
-				"    #BEGIN_CLASS_HEADER\n" +
-				"    __test__ = False\n"
-		);
-		assertThat(implText, is(not(newText)));
-		FileUtils.writeStringToFile(implFile.toFile(), newText);
-		
 		int exitCode = runTestsInDocker(moduleDir.toFile());
 		assertEquals(0, exitCode);
 	}


### PR DESCRIPTION
Removes the need for a base image for python modules. There really aren't many requirements for an SDK app to run that aren't provided by a standard python image:

* The SDK executable
* 6 python modules

Also

* Switches to pytest since nose is 10 years out of date and incompatible with modern python versions
* Removes the user-env.sh call that does nothing in the most recent python base image

Registration test:
https://ci.kbase.us/legacy/catalog/register/1757885720925_668686dd-7549-400f-a1ff-1fcd368c896e