### PR TITLE
Fix a bug that prevents java compilation

### DIFF
--- a/src/main/java/us/kbase/sdk/compiler/RunCompileCommand.java
+++ b/src/main/java/us/kbase/sdk/compiler/RunCompileCommand.java
@@ -40,7 +40,7 @@ public class RunCompileCommand {
             boolean pyServerSide,
             final String pyServerName, 
             final String pyImplName,
-            boolean javaClientSide,
+            final boolean javaClientSide,
             final boolean javaServerSide, 
             final String javaPackageParent,
             final String javaSrcPath,
@@ -124,7 +124,8 @@ public class RunCompileCommand {
             }
         }
         JavaData javaParsingData = null;
-        if (javaClientSide) {
+        // TODO TEST the missing javaServerSide bool was not caught in tests
+        if (javaClientSide || javaServerSide) {
             //TODO DYNSERV add dynamic service client generation to all clients except Python
             javaParsingData = JavaTypeGenerator.processSpec(services, javaSrcDir, 
                     javaPackageParent, javaServerSide, url,


### PR DESCRIPTION
... unless a client is requested.

This bug was introduced when removing code that forced client compilation when the server was requested. It apparently was not detected because the tests run in docker containers where the old kb-sdk recompiles the spec. It was discovered when replacing the base image and using the new graalvm compiled binary.