### PR TITLE
Eliminate java base image

### DIFF
--- a/src/main/resources/us/kbase/sdk/templates/module_build_xml.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_build_xml.vm.properties
@@ -19,6 +19,7 @@
   <property name="startup.cmd.file" value="start_server.sh"/>
 
   <fileset dir="${jars.dir}" id="lib">
+    <include name="annotation/javax.annotation-api-1.3.2.jar"/>
     <include name="ini4j/ini4j-0.5.2.jar"/>
     <include name="jackson/jackson-annotations-2.2.3.jar"/>
     <include name="jackson/jackson-core-2.2.3.jar"/>

--- a/src/main/resources/us/kbase/sdk/templates/module_dockerfile.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_dockerfile.vm.properties
@@ -1,11 +1,10 @@
 #if($language == "python")
 FROM python:3.12-trixie
 #else
-FROM kbase/sdkbase2:latest
+FROM eclipse-temurin:17.0.16_8-jdk-noble
 #end
 LABEL maintainer=#if($username)${username}#{else}"KBase Developer"#{end}
 
-#if($language == "python")
 # -----------------------------------------
 # Set up SDK requirements
 
@@ -15,17 +14,24 @@ LABEL maintainer=#if($username)${username}#{else}"KBase Developer"#{end}
 ENV PIP_PROGRESS_BAR=off
 
 # Install general binaries
+#if($language == "python") 
 RUN apt update && apt install -y wget
+#else
+RUN apt update && apt install -y wget make git ant \
+    python3.12 python-is-python3 python3-jinja2=3.1.2-1ubuntu1.3
+#end
 
 # Install the SDK binary. This is required for spec compilation and catalog registration.
-ENV SDK_VER=0.1.0-alpha4
-ENV SDK_SHA=abd85762e5ec9c56533e77639b4367cf2e0762971c5c58589bf8d96ffb203e55
+ENV SDK_VER=0.1.0-alpha5
+ENV SDK_SHA=52b73fd3fb1fe1c5fa5d1fa6298587093cf2368d2cac9fae8ebdb2f3765b72db
 RUN mkdir -p /sdk/bin \
     && wget -q -O /sdk/bin/kb-sdk https://github.com/kbase/kb_sdk_plus/releases/download/$SDK_VER/kb-sdk-linux-x64 \
     && echo "$SDK_SHA /sdk/bin/kb-sdk" | sha256sum --check \
     && chmod a+x /sdk/bin/kb-sdk
 ENV PATH=/sdk/bin:$PATH
 
+
+#if($language == "python")
 # Install python libraries required by the SDK code.
 # You may wish to use a dependency manager like pipenv or uv to install
 # these as well as your own dependencies.
@@ -37,6 +43,15 @@ RUN pip install \
     uwsgi==2.0.30 \
     pytest==8.4.2 \
     pytest-cov==6.2.1
+#else
+# Install the jars repo.
+# docker-java-shaded contains log4j w/ vuln, hence the delete
+RUN mkdir -p /opt/jars_temp \
+    && cd /opt/jars_temp \
+    && git clone https://github.com/kbase/jars.git \
+    && rm jars/lib/jars/dockerjava/docker-java-shaded-3.0.14.jar \
+    && mv /opt/jars_temp/jars/lib/jars /opt/jars \
+    && rm -r /opt/jars_temp
 #end
 
 # -----------------------------------------
@@ -53,7 +68,7 @@ RUN pip install \
 RUN pip install biopython==1.85
 #else
 # download a fasta reader/writer
-RUN cd /kb/deployment/lib/jars \
+RUN cd /opt/jars \
     && wget https://downloads.sourceforge.net/project/jfasta/releases/jfasta-2.2.0/jfasta-2.2.0-jar-with-dependencies.jar
 #end
 #end

--- a/src/main/resources/us/kbase/sdk/templates/module_makefile.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_makefile.vm.properties
@@ -9,17 +9,11 @@ TEST_DIR = test
 LBIN_DIR = bin
 WORK_DIR = /kb/module/work/tmp
 #if($language == "java")
-TARGET ?= /kb/deployment
-JARS_DIR = $(TARGET)/lib/jars
+JARS_DIR = /opt/jars
 #end
 EXECUTABLE_SCRIPT_NAME = run_$(SERVICE_CAPS)_async_job.sh
 STARTUP_SCRIPT_NAME = start_server.sh
 TEST_SCRIPT_NAME = run_tests.sh
-#if($language == "java")
-KB_RUNTIME ?= /kb/runtime
-ANT_HOME ?= $(KB_RUNTIME)/ant
-ANT = $(ANT_HOME)/bin/ant
-#end
 
 TEST_SPEC = .
 
@@ -44,7 +38,7 @@ compile:
 
 build:
 #if($language == "java")
-	$(ANT) war -Djars.dir=$(JARS_DIR)
+	ant war -Djars.dir=$(JARS_DIR)
 #end
 	chmod +x $(SCRIPTS_DIR)/entrypoint.sh
 
@@ -57,7 +51,7 @@ build-executable-script:
 	echo 'python -u $$script_dir/../$(LIB_DIR)/$(SERVICE_CAPS)/$(SERVICE_CAPS)Server.py $$1 $$2 $$3' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
 #end
 #if($language == "java")
-	$(ANT) build-executable-script -Djars.dir=$(JARS_DIR) -Dexec.cmd.file=$(EXECUTABLE_SCRIPT_NAME)
+	ant build-executable-script -Djars.dir=$(JARS_DIR) -Dexec.cmd.file=$(EXECUTABLE_SCRIPT_NAME)
 #end
 	chmod +x $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
 
@@ -92,7 +86,7 @@ build-test-script:
 #end
 #if($language == "java")
 	echo 'export JAVA_HOME=$(JAVA_HOME)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo '$(ANT) test -Djars.dir=$(JARS_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'ant test -Djars.dir=$(JARS_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 #end
 	chmod +x $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 

--- a/src/main/resources/us/kbase/sdk/templates/module_prepare_deploy_cfg.vm.properties
+++ b/src/main/resources/us/kbase/sdk/templates/module_prepare_deploy_cfg.vm.properties
@@ -2,12 +2,8 @@ import sys
 import os
 import os.path
 from jinja2 import Template
-try:
-    from configparser import ConfigParser
-    from io import StringIO
-except ImportError:
-    from ConfigParser import ConfigParser
-    from StringIO import StringIO
+from configparser import ConfigParser
+from io import StringIO
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
@@ -39,11 +35,7 @@ if __name__ == "__main__":
             if key.startswith('KBASE_SECURE_CONFIG_PARAM_'):
                 param_name = key[len('KBASE_SECURE_CONFIG_PARAM_'):]
                 props += param_name + " = " + os.environ.get(key) + "\n"
-        # TODO BASEIMAGE remove when updating java docker file to py3
-        if hasattr(config, "read_file"):
-            config.read_file(StringIO(props))   # Python 3
-        else:
-            config.readfp(StringIO(props))   # Python 2 - Remove after updating java base image
+        config.read_file(StringIO(props))
     else:
         raise ValueError('Neither ' + sys.argv[2] + ' file nor KBASE_ENDPOINT env-variable found')
     props = dict(config.items("global"))


### PR DESCRIPTION
Installs the few requirements for java SDK modules to run directly in the module dockerfile:

* make ant git python etc (and we should look into removing the need for python)
* the kb-sdk binary
* the jars repo (which ideally we'll eliminate with a switch to gradle at some point)

Registration test:
https://ci.kbase.us/legacy/catalog/register/1757971612478_bd557261-674a-4057-b23d-3e8fc0213e7b