### PR TITLE
allow jackson to sync versions across dep graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,15 +300,11 @@ dependencies {
 	annotationProcessor('info.picocli:picocli-codegen:4.7.7')
 	compileOnly('javax.servlet:servlet-api:2.5')
 
-	implementation('com.github.kbase:auth2_client_java:0.5.0') {
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
-	}
+	implementation('com.github.kbase:auth2_client_java:0.5.0')
 	implementation('com.github.kbase:catalog:2.3.1') {
 		exclude group: 'com.github.kbase', module: 'java_common'
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 	}
 	implementation('com.github.kbase:java_common:0.3.1') {
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 		exclude group: 'net.java.dev.jna' // don't include in runtime path
 		exclude group: 'org.eclipse.jetty.aggregate' // don't include in runtime path
 		exclude group: 'org.syslog4j', module: 'syslog4j'
@@ -316,13 +312,12 @@ dependencies {
 	implementation('com.github.kbase:java_kidl:0.2.0')
 	implementation('com.github.kbase:narrative_method_store:v0.3.13') {
 		exclude group: 'com.github.kbase', module: 'java_common'
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 		// TODO DEPS fix these in NMS
 		exclude group: 'org.mongodb'
 		exclude group: 'org.eclipse.jetty.aggregate' // don't include in runtime path
 	}
-	implementation('com.fasterxml.jackson.core:jackson-annotations:2.2.3')
-	implementation('com.fasterxml.jackson.core:jackson-databind:2.2.3')
+	implementation('com.fasterxml.jackson.core:jackson-annotations:2.9.9')
+	implementation('com.fasterxml.jackson.core:jackson-databind:2.9.9')
 	implementation('com.google.guava:guava:18.0')
 	implementation('com.googlecode.jsonschema2pojo:jsonschema2pojo-core:0.3.6')
 	implementation('com.j2html:j2html:0.7') {
@@ -343,14 +338,10 @@ dependencies {
 
 	testImplementation('ch.qos.logback:logback-classic:1.1.2')
 	testImplementation ('com.github.kbase:java_test_utilities:0.1.0') {
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
 		exclude group: 'junit', module: 'junit'
 	}
-	testImplementation('com.github.kbase.workspace_deluxe:workspace-client:0.15.0') {
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
-		exclude group: 'net.java.dev.jna' // don't include in runtime path
-	}
-	// needed for syslog4j. Used in java test modules and JsonServerServlet subclasses in tests
+	testImplementation('com.github.kbase.workspace_deluxe:workspace-client:0.15.0')
+	// needed for syslog4j. Used in JsonServerServlet subclasses in tests
 	// but not in SDK code proper.
 	testImplementation('net.java.dev.jna:jna:3.4.0')
 	testImplementation("nl.jqno.equalsverifier:equalsverifier:4.0.7")
@@ -368,17 +359,9 @@ dependencies {
 	
 	// isolate the sdk generated code dependencies from the standard dependencies
 	
-	generatedCodeClasspath('ch.qos.logback:logback-classic:1.1.2')
-	generatedCodeClasspath('com.fasterxml.jackson.core:jackson-databind:2.2.3')
-	generatedCodeClasspath('com.github.kbase:auth2_client_java:0.5.0') {
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
-	}
-	generatedCodeClasspath('com.github.kbase:java_common:0.3.1') {
-		exclude group: 'com.fasterxml.jackson.core'  // don't upgrade yet, breaks tests
-	}
+	generatedCodeClasspath('com.github.kbase:auth2_client_java:0.5.0')
+	generatedCodeClasspath('com.github.kbase:java_common:0.3.1')
 	generatedCodeClasspath('javax.annotation:javax.annotation-api:1.3.2')
-	generatedCodeClasspath('org.ini4j:ini4j:0.5.2')
-	generatedCodeClasspath('org.syslog4j:syslog4j:0.9.46')
 
 	generatedTestCodeClasspath('junit:junit:4.12')
 }


### PR DESCRIPTION
Allows for writing out the generated code dependencies to generate a build.gradle file in kb-sdk init